### PR TITLE
Fix issues 76, 77, and IPSec network lifetime

### DIFF
--- a/codegen/customizations.yml
+++ b/codegen/customizations.yml
@@ -477,6 +477,8 @@ customizations:
           customUnmarshalType: ""
     Network:
       fields:
+        FirewallZoneID:
+          omitEmpty: true
         InternetAccessEnabled:
           ifFieldType: "bool"
           customUnmarshalType: "*bool"
@@ -485,6 +487,10 @@ customizations:
           ifFieldType: "bool"
           customUnmarshalType: "*bool"
           customUnmarshalFunc: "emptyBoolToTrue"
+        IPSecEspLifetime:
+          fieldType: "int"
+        IPSecIkeLifetime:
+          fieldType: "int"
         WANUsername:
           omitEmpty: true
         XWANPassword:

--- a/codegen/v2/FirewallZonePolicy.json
+++ b/codegen/v2/FirewallZonePolicy.json
@@ -8,8 +8,8 @@
     "name": "",
     "description": "",
     "destination": {
-        "app_category_ids": [""],
-        "app_ids": [""],
+        "app_category_ids": ["[0-9]*"],
+        "app_ids": ["[0-9]*"],
         "ip_group_id": "",
         "ips": ["^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$"],
         "match_opposite_ips": "true|false",

--- a/unifi/firewall_zone_policy.generated.go
+++ b/unifi/firewall_zone_policy.generated.go
@@ -65,8 +65,8 @@ func (dst *FirewallZonePolicy) UnmarshalJSON(b []byte) error {
 }
 
 type FirewallZonePolicyDestination struct {
-	AppCategoryIDs     []string `json:"app_category_ids,omitempty"`
-	AppIDs             []string `json:"app_ids,omitempty"`
+	AppCategoryIDs     []int    `json:"app_category_ids,omitempty"`
+	AppIDs             []int    `json:"app_ids,omitempty"`
 	IPGroupID          string   `json:"ip_group_id,omitempty"`
 	IPs                []string `json:"ips,omitempty" validate:"omitempty,ipv4"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	MatchOppositeIPs   bool     `json:"match_opposite_ips"`
@@ -84,6 +84,9 @@ type FirewallZonePolicyDestination struct {
 func (dst *FirewallZonePolicyDestination) UnmarshalJSON(b []byte) error {
 	type Alias FirewallZonePolicyDestination
 	aux := &struct {
+		AppCategoryIDs []emptyStringInt `json:"app_category_ids"`
+		AppIDs         []emptyStringInt `json:"app_ids"`
+
 		*Alias
 	}{
 		Alias: (*Alias)(dst),
@@ -92,6 +95,14 @@ func (dst *FirewallZonePolicyDestination) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, &aux)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.AppCategoryIDs = make([]int, len(aux.AppCategoryIDs))
+	for i, v := range aux.AppCategoryIDs {
+		dst.AppCategoryIDs[i] = int(v)
+	}
+	dst.AppIDs = make([]int, len(aux.AppIDs))
+	for i, v := range aux.AppIDs {
+		dst.AppIDs[i] = int(v)
 	}
 
 	return nil

--- a/unifi/firewall_zone_policy.generated.go
+++ b/unifi/firewall_zone_policy.generated.go
@@ -65,8 +65,8 @@ func (dst *FirewallZonePolicy) UnmarshalJSON(b []byte) error {
 }
 
 type FirewallZonePolicyDestination struct {
-	AppCategoryIDs     []string `json:"app_category_ids,omitempty"`
-	AppIDs             []string `json:"app_ids,omitempty"`
+	AppCategoryIDs     []int    `json:"app_category_ids,omitempty"`
+	AppIDs             []int    `json:"app_ids,omitempty"`
 	IPGroupID          string   `json:"ip_group_id,omitempty"`
 	IPs                []string `json:"ips,omitempty" validate:"omitempty,dive,ipv4"` // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	MatchOppositeIPs   bool     `json:"match_opposite_ips"`
@@ -84,6 +84,9 @@ type FirewallZonePolicyDestination struct {
 func (dst *FirewallZonePolicyDestination) UnmarshalJSON(b []byte) error {
 	type Alias FirewallZonePolicyDestination
 	aux := &struct {
+		AppCategoryIDs []emptyStringInt `json:"app_category_ids"`
+		AppIDs         []emptyStringInt `json:"app_ids"`
+
 		*Alias
 	}{
 		Alias: (*Alias)(dst),
@@ -92,6 +95,14 @@ func (dst *FirewallZonePolicyDestination) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, &aux)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.AppCategoryIDs = make([]int, len(aux.AppCategoryIDs))
+	for i, v := range aux.AppCategoryIDs {
+		dst.AppCategoryIDs[i] = int(v)
+	}
+	dst.AppIDs = make([]int, len(aux.AppIDs))
+	for i, v := range aux.AppIDs {
+		dst.AppIDs[i] = int(v)
 	}
 
 	return nil

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -75,7 +75,7 @@ type Network struct {
 	DomainName                                    string                          `json:"domain_name"`                              // (?=^.{3,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)|^$|[a-zA-Z0-9-]{1,63}
 	Enabled                                       bool                            `json:"enabled"`
 	ExposedToSiteVPN                              bool                            `json:"exposed_to_site_vpn"`
-	FirewallZoneID                                string                          `json:"firewall_zone_id"`
+	FirewallZoneID                                string                          `json:"firewall_zone_id,omitempty"`
 	GatewayDevice                                 string                          `json:"gateway_device" validate:"omitempty,mac"`                          // (^$|^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$)
 	GatewayType                                   string                          `json:"gateway_type,omitempty" validate:"omitempty,oneof=default switch"` // default|switch
 	IGMPFastleave                                 bool                            `json:"igmp_fastleave"`


### PR DESCRIPTION
This should fix issues [76](https://github.com/filipowm/go-unifi/issues/76) and [77](https://github.com/filipowm/go-unifi/issues/77) as well as a unlisted issues I bumped into in testing where both IPSecEspLifetime and IPSecIkeLifetime are Ints but codegen marks as string.
