### PR TITLE
fix: use pointer for DeviceQOSProfile to respect omitempty

### DIFF
--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -336,7 +336,7 @@ type DevicePortOverrides struct {
 	PriorityQueue2Level          int              `json:"priority_queue2_level,omitempty"`                              // [0-9]|[1-9][0-9]|100
 	PriorityQueue3Level          int              `json:"priority_queue3_level,omitempty"`                              // [0-9]|[1-9][0-9]|100
 	PriorityQueue4Level          int              `json:"priority_queue4_level,omitempty"`                              // [0-9]|[1-9][0-9]|100
-	QOSProfile                   DeviceQOSProfile `json:"qos_profile,omitempty"`
+	QOSProfile                   *DeviceQOSProfile `json:"qos_profile,omitempty"`
 	SettingPreference            string           `json:"setting_preference,omitempty" validate:"omitempty,oneof=auto manual"`                                   // auto|manual
 	Speed                        int              `json:"speed,omitempty" validate:"omitempty,oneof=10 100 1000 2500 5000 10000 20000 25000 40000 50000 100000"` // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
 	StormctrlBroadcastastEnabled bool             `json:"stormctrl_bcast_enabled,omitempty"`


### PR DESCRIPTION
## Summary

- Change `QOSProfile DeviceQOSProfile` to `QOSProfile *DeviceQOSProfile` in `DevicePortOverrides` so `json:",omitempty"` correctly omits the field when nil

## Problem

Go's `encoding/json` never considers a zero-value struct as "empty" for `omitempty` — only nil pointers, empty strings/slices, and zero numbers. Because `QOSProfile` is a value type, the JSON serializer always emits `"qos_profile":{}` in port override payloads, even when no QoS configuration is set.

This causes UniFi OS consoles (confirmed on UDM SE) to reject the PUT with `api.err.NotSupportQosConfig`, making it impossible to manage device port overrides via the API (and by extension, via the Terraform provider).

## Fix

One-character change: `DeviceQOSProfile` → `*DeviceQOSProfile`. When the pointer is nil, `omitempty` correctly omits the field from the JSON payload.

## References

- paultyng/go-unifi#53 — upstream issue describing this exact problem
- Confirmed on UDM SE running UniFi OS 5.0.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)