### PR TITLE
fix: always serialize FirewallGroup group_members, even when empty

### DIFF
--- a/codegen/customizations.yml
+++ b/codegen/customizations.yml
@@ -557,3 +557,14 @@ customizations:
       fields:
         ScheduleWithDuration:
           omitEmpty: false
+    FirewallGroup:
+      fields:
+        # GroupMembers is a slice that defaults to empty when no members are
+        # configured. With omitempty (the default behavior for slices), an
+        # empty slice gets entirely omitted from the JSON payload, and UniFi
+        # creates the resource without the field. The Network app's Settings
+        # page then chokes on `undefined.length` when iterating members.
+        # Force the field to always be sent — empty slice serializes to `[]`
+        # which the UI handles correctly.
+        GroupMembers:
+          omitEmpty: false

--- a/unifi/firewall_group.generated.go
+++ b/unifi/firewall_group.generated.go
@@ -25,7 +25,7 @@ type FirewallGroup struct {
 	NoDelete bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
-	GroupMembers []string `json:"group_members,omitempty"`
+	GroupMembers []string `json:"group_members"`
 	GroupType    string   `json:"group_type,omitempty" validate:"omitempty,oneof=address-group port-group ipv6-address-group"` // address-group|port-group|ipv6-address-group
 	Name         string   `json:"name,omitempty" validate:"omitempty,gte=1,lte=64"`                                            // .{1,64}
 }


### PR DESCRIPTION
## Problem

`FirewallGroup.group_members` is legitimately empty when a group has no members yet (e.g. a pre-declared address group that firewall rules will reference later). With `omitempty` — the generator's default for slices — an empty slice is **omitted from the payload entirely**, so the controller stores the group without the field. The Network app's **Settings page** then throws `TypeError: Cannot read properties of undefined (reading 'length')` iterating the missing array, and the page fails to render.

## Fix

`omitEmpty: false` for the field via `codegen/customizations.yml`, so an empty member list serializes as `[]` — which the UI handles correctly. Regenerated at the pinned controller version (9.3.45); the generated diff is a single json-tag change.

Note this is the *inverse* of the omitEmpty additions in #111 (and #81): those suppress empty *strings* that shouldn't be sent; this forces an empty *array* that must be. Split into its own PR for that reason.

## Validation

Running in production against a UXG (controller 9.x) since 2026-05 via a downstream fork, including empty pre-declared groups (Terraform-managed). `go build ./...` and `go test ./unifi/` pass.