### PR TITLE
feat(official): Official-API runtime seam + info/sites vertical (#119)

### DIFF
--- a/.claude/rules/go-conventions.md
+++ b/.claude/rules/go-conventions.md
@@ -11,6 +11,12 @@ Never edit `*.generated.go`. These rules apply to hand-written `.go` files.
 - Generated CRUD methods are private (`getUser`, `listUser`, `createUser`). Expose them via public wrappers in the hand-written sibling: `GetUser`,
   `ListUser`, etc. Put custom logic (search-by-MAC, field init, custom marshaling) in the wrapper, not the generated file.
 
+## Official API (`unifi/official`)
+- One-way dependency: `unifi -> official`. The `official` package MUST import nothing from `unifi`; the transport is injected as the structural `Doer`
+  (Get/Post/Put/Delete) and the capability check as a `Gate`. `*unifi.client` satisfies `Doer` via its public request methods.
+- Official wrappers pass FULL leading-`/` paths (under `integrationV1Path`); `buildRequestURL` resolves them against the base URL, bypassing `APIPaths.ApiPath`.
+- The Internal/Official split lives in `official_surface.go` (`Internal()`/`Official()` + the gate); do not hand-edit the split in `client.generated.go`.
+
 ## HTTP & client
 - Use `c.Get/Post/Put/Delete` (or `c.Do`) from `requests.go`; don't build raw `http.Request`s.
 - Every method takes `context.Context` first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ hand-written layer wraps them with a usable client.
 - To change generated output: edit `codegen/customizations.yml` (field type/name/tags/unmarshalers) and regenerate, OR add a hand-written sibling `.go` file.
   See `codegen/CLAUDE.md`.
 - Generated CRUD methods are private (`getUser`, `listUser`); public wrappers (`GetUser`, `ListUser`) live in hand-written `.go` siblings.
+- The generated `Client` interface embeds `InternalClient` (all resource CRUD) and adds transport/lifecycle methods plus `Internal()`/`Official()` accessors. The Official API (`unifi/official`) is a one-way dependency (`unifi -> official`): it imports nothing back, taking the transport as a structural `Doer`.
 
 ## Commands
 
@@ -37,7 +38,9 @@ unifi/                  Single Go package: client + all resource types
   json.go               Special unmarshalers (emptyStringInt, numberOrString, ...)
   *.generated.go        GENERATED — do not edit
   <resource>.go         Hand-written wrappers/business logic for <resource>
+  official_surface.go   Internal()/Official() accessors + the Official-API capability gate
   features/             Controller feature-flag constants
+  official/             Official UniFi OpenAPI (integration/v1) client — imports NOTHING from unifi
 codegen/                Code-generation pipeline (see codegen/CLAUDE.md)
 docs/                   Documentation
 .unifi-version          Supported controller version marker (e.g. 9.3.45)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ SkipVerifySSL: true, // disable TLS verification (self-signed cert)
 
 List of available client configuration options is available [here](https://pkg.go.dev/github.com/filipowm/go-unifi/unifi#ClientConfig).
 
+### Internal vs Official API
+
+The client exposes two API surfaces:
+
+- **Internal** — the legacy UniFi Network API the SDK has always wrapped. Every resource method
+  (`GetNetwork`, `ListUser`, …) lives here and is reachable directly on the client *or* via `c.Internal()`.
+- **Official** — the official UniFi OpenAPI (`integration/v1`), reached via `c.Official()`. It requires a
+  new-style UniFi OS controller (version `10.1.68`+) with **API-key** authentication.
+
+```go
+sites, err := c.Internal().ListSites(ctx)          // legacy API (same as c.ListSites(ctx))
+info, err := c.Official().GetInfo(ctx)             // official OpenAPI
+id, err := c.Official().ResolveSiteID(ctx, "default") // map a legacy site name to its official UUID
+```
+
+In **2.0.0 the Internal surface stays the canonical default**, so existing code is untouched — calling a
+resource method on the client is identical to calling it on `c.Internal()`. **3.0.0 is expected to flip the
+default to the Official client.** The Official client is gated: operations return
+`unifi.ErrOfficialAPIUnavailable` on a classic/old-style controller, non-API-key auth, or a controller
+below `10.1.68`, and `unifi.ErrOfficialAPIDisabled` when `ClientConfig.DisableOfficialAPI` is set. Match
+either with `errors.Is`. Site identifiers differ between the surfaces — the Internal API uses the site
+**name** while the Official API uses a **UUID** — so `Official().ResolveSiteID` maps the familiar name to
+the UUID for you.
+
 ### Customizing HTTP Client
 
 You can customize underlying HTTP client by using `HttpTransportCustomizer` interface:

--- a/codegen/CLAUDE.md
+++ b/codegen/CLAUDE.md
@@ -11,6 +11,16 @@ which runs: `go run ../codegen/ -version-base-dir=../codegen/ <version>`.
 3. `customize.go` — applies `customizations.yml` field overrides.
 4. `generator.go` — renders `api.go.tmpl` / `apiv2.go.tmpl` → `<resource>.generated.go`; writes `version.generated.go` and the repo `.unifi-version` marker.
 
+### Client interface split (`client.go.tmpl` + `clients.go`)
+
+`client.go.tmpl` renders **two** interfaces into `client.generated.go`: an embedded `InternalClient` (all
+resource CRUD — every function carrying a resource name) and the top-level `Client` (which embeds
+`InternalClient`, then lists the transport/lifecycle functions — those with an *empty* resource name — and
+the hand-written `Internal()`/`Official()` accessors). The split is driven by `ClientInfo.ResourceFunctions`
+/ `ClientInfo.TransportFunctions` in `clients.go`, keyed on `ClientFunction.ResourceName()`. The template
+always imports `unifi/official` for the `Official()` accessor return type. After changing the split,
+regenerate `client.generated.go` **and** `client_mock.generated.go` (offline moq — see `unifi/mock.go`).
+
 ## Download trust model (ARCH-15 / ARCH-16)
 
 The download pipeline (`download.go`, `version.go`) is the only point where codegen

--- a/codegen/client.go.tmpl
+++ b/codegen/client.go.tmpl
@@ -5,14 +5,18 @@ package unifi
 
 import (
 	"context"
-	{{ range $k, $v := .Imports }}"{{ $v }}"{{- end }}
+	{{- range $k, $v := .Imports }}
+	"{{ $v }}"
+	{{- end }}
+
+	"github.com/filipowm/go-unifi/unifi/official"
 )
 
-type {{ .Name }} interface {
-
-    Logger
-
-    {{- range $k, $v := .Functions }}
+// InternalClient is the legacy UniFi Network ("Internal") API surface: every
+// resource CRUD method. In 2.0.0 this is the canonical client; 3.0.0 is expected
+// to flip the default to the Official OpenAPI client.
+type InternalClient interface {
+    {{- range $k, $v := .ResourceFunctions }}
 
     {{ if $v.Comment }}// {{ $v.Comment }}{{ end }}
     {{ $v.Signature }}
@@ -20,4 +24,25 @@ type {{ .Name }} interface {
     {{- end }}
 }
 
+// {{ .Name }} is the top-level UniFi client. It embeds InternalClient (the legacy
+// resource API), adds transport/lifecycle methods, and exposes the Internal()
+// and Official() API-surface accessors.
+type {{ .Name }} interface {
 
+    Logger
+
+    InternalClient
+
+    {{- range $k, $v := .TransportFunctions }}
+
+    {{ if $v.Comment }}// {{ $v.Comment }}{{ end }}
+    {{ $v.Signature }}
+
+    {{- end }}
+
+    // Internal returns the legacy ("Internal") UniFi Network API client.
+    Internal() InternalClient
+
+    // Official returns the Official UniFi OpenAPI client.
+    Official() official.Client
+}

--- a/codegen/clients.go
+++ b/codegen/clients.go
@@ -108,6 +108,33 @@ func (c *ClientInfo) Name() string {
 	return "Client"
 }
 
+// ResourceFunctions returns the resource-bound functions (standard CRUD plus
+// custom resource methods), which make up the embedded InternalClient interface.
+// They are distinguished from transport/lifecycle functions by carrying a
+// resource name.
+func (c *ClientInfo) ResourceFunctions() []ClientFunction {
+	return filterFunctions(c.Functions, func(f ClientFunction) bool { return f.ResourceName() != "" })
+}
+
+// TransportFunctions returns the transport/lifecycle functions (Do/Get/Post/Put/
+// Delete, Login/Logout, Version, BaseURL, ...), which sit on the top-level Client
+// interface alongside the Internal()/Official() accessors. They are the functions
+// with no resource name.
+func (c *ClientInfo) TransportFunctions() []ClientFunction {
+	return filterFunctions(c.Functions, func(f ClientFunction) bool { return f.ResourceName() == "" })
+}
+
+// filterFunctions returns the subset of fns satisfying keep, preserving order.
+func filterFunctions(fns []ClientFunction, keep func(ClientFunction) bool) []ClientFunction {
+	out := make([]ClientFunction, 0, len(fns))
+	for _, f := range fns {
+		if keep(f) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 //go:embed client.go.tmpl
 var clientGoTemplate string
 

--- a/docs/2.0.0/breaking_changes.md
+++ b/docs/2.0.0/breaking_changes.md
@@ -204,3 +204,46 @@ It is **not** `ErrNotFound` (`errors.Is(err, ErrNotFound) == false`), so genuine
 > Note (internal): the `codegen` tool's `DownloadAndExtract`/`downloadJar` gained a leading
 > `context.Context` parameter (ARCH-15). This is not part of the public `unifi` API surface and affects
 > only forks of the generator.
+
+## 2.0.0 — Official API seam (#119)
+
+The Official UniFi OpenAPI (`integration/v1`) lands behind a runtime seam. The `Client` interface is split
+and gains `Internal()`/`Official()` accessors; the Official surface is gated on controller capability.
+
+### 1. `Client` interface split into embedded `InternalClient` + accessors (#119)
+
+**Interface change (compile break for custom `Client` implementations).** The generated `Client` interface
+now embeds a new `InternalClient` interface (all resource CRUD) and adds two accessors:
+
+```go
+type InternalClient interface { /* GetNetwork, ListNetwork, …, all resource CRUD */ }
+
+type Client interface {
+	Logger
+	InternalClient             // embedded — every resource method, unchanged
+	// transport/lifecycle: Do/Get/Post/Put/Delete, Login*/Logout*, Version*, BaseURL
+	Internal() InternalClient  // returns the legacy ("Internal") client (self)
+	Official() official.Client // returns the Official OpenAPI client
+}
+```
+
+Existing call sites are **source-compatible**: `client.GetNetwork(...)` still works (the methods are
+embedded), and `client.Internal().GetNetwork(...)` is the new explicit form. Any third-party type that
+implements `unifi.Client` (e.g. a hand-rolled fake) must now also implement `Internal()` and `Official()`;
+the moq-generated `ClientMock` is regenerated automatically and needs no manual change. This is the
+**2.0.0-canonical-Internal** step: in 2.0.0 the embedded Internal surface stays the default so existing
+code is untouched; 3.0.0 is expected to flip the default to the Official client (the **3.0.0-flip**).
+
+### 2. Official API unavailable on classic/old-style controllers (#119)
+
+**New runtime contract (no compile break).** `client.Official()` always returns a non-nil client, but its
+operations are gated. They return:
+
+- `ErrOfficialAPIDisabled` when `ClientConfig.DisableOfficialAPI` is set (fails fast, no probe);
+- `ErrOfficialAPIUnavailable` on an old-style (classic) controller, non-API-key auth, or a controller
+  version below `10.1.68` (the first release exposing `integration/v1`).
+
+Match with `errors.Is(err, unifi.ErrOfficialAPIUnavailable)` / `…ErrOfficialAPIDisabled`. The Internal API
+is unaffected. Note that **classic/old-style controllers are unsupported for 2.0.0's API-key-only auth**
+(the Official API requires a new-style UniFi OS controller); epic #117's breaking-changes table should
+gain a *"classic/old-style controllers unsupported in 2.0.0"* row to reflect this.

--- a/unifi/api_paths.go
+++ b/unifi/api_paths.go
@@ -14,6 +14,11 @@ const (
 	apiPathNew   = "/proxy/network/api"
 	apiV2PathNew = "/proxy/network/v2/api"
 
+	// integrationV1Path is the base prefix for the Official UniFi OpenAPI
+	// (integration/v1). It is a capability layered on the new-style API, not a
+	// fourth APIStyle: full leading-slash paths under it bypass APIPaths.ApiPath.
+	integrationV1Path = "/proxy/network/integration/v1"
+
 	loginPath    = "/api/login"
 	loginPathNew = "/api/auth/login"
 

--- a/unifi/client.generated.go
+++ b/unifi/client.generated.go
@@ -6,47 +6,14 @@ package unifi
 import (
 	"context"
 	"io"
+
+	"github.com/filipowm/go-unifi/unifi/official"
 )
 
-type Client interface {
-	Logger
-
-	// BaseURL returns the base URL of the controller.
-	BaseURL() string
-
-	// Delete sends a DELETE request to the controller.
-	Delete(ctx context.Context, apiPath string, reqBody any, respBody any) error
-
-	// Do sends a request to the controller.
-	Do(ctx context.Context, method string, apiPath string, reqBody any, respBody any) error
-
-	// Get sends a GET request to the controller.
-	Get(ctx context.Context, apiPath string, reqBody any, respBody any) error
-
-	// Login logs in to the controller. Useful only for user/password authentication.
-	Login() error
-
-	// LoginContext logs in to the controller using the supplied context for cancellation/deadline. Useful only for user/password authentication.
-	LoginContext(ctx context.Context) error
-
-	// Logout logs out from the controller.
-	Logout() error
-
-	// LogoutContext logs out from the controller using the supplied context for cancellation/deadline.
-	LogoutContext(ctx context.Context) error
-
-	// Post sends a POST request to the controller.
-	Post(ctx context.Context, apiPath string, reqBody any, respBody any) error
-
-	// Put sends a PUT request to the controller.
-	Put(ctx context.Context, apiPath string, reqBody any, respBody any) error
-
-	// Version returns the version of the UniFi Controller API.
-	Version() string
-
-	// VersionContext returns the version of the UniFi Controller API using the supplied context, surfacing any fetch error instead of swallowing it.
-	VersionContext(ctx context.Context) (string, error)
-
+// InternalClient is the legacy UniFi Network ("Internal") API surface: every
+// resource CRUD method. In 2.0.0 this is the canonical client; 3.0.0 is expected
+// to flip the default to the Official OpenAPI client.
+type InternalClient interface {
 	// ==== client methods for APGroup resource ====
 
 	// CreateAPGroup creates a resource
@@ -1193,5 +1160,55 @@ type Client interface {
 	// ==== end of client methods for WLANGroup resource ====
 
 	// ==== end of client methods for WLAN resource ====
+}
 
+// Client is the top-level UniFi client. It embeds InternalClient (the legacy
+// resource API), adds transport/lifecycle methods, and exposes the Internal()
+// and Official() API-surface accessors.
+type Client interface {
+	Logger
+
+	InternalClient
+
+	// BaseURL returns the base URL of the controller.
+	BaseURL() string
+
+	// Delete sends a DELETE request to the controller.
+	Delete(ctx context.Context, apiPath string, reqBody any, respBody any) error
+
+	// Do sends a request to the controller.
+	Do(ctx context.Context, method string, apiPath string, reqBody any, respBody any) error
+
+	// Get sends a GET request to the controller.
+	Get(ctx context.Context, apiPath string, reqBody any, respBody any) error
+
+	// Login logs in to the controller. Useful only for user/password authentication.
+	Login() error
+
+	// LoginContext logs in to the controller using the supplied context for cancellation/deadline. Useful only for user/password authentication.
+	LoginContext(ctx context.Context) error
+
+	// Logout logs out from the controller.
+	Logout() error
+
+	// LogoutContext logs out from the controller using the supplied context for cancellation/deadline.
+	LogoutContext(ctx context.Context) error
+
+	// Post sends a POST request to the controller.
+	Post(ctx context.Context, apiPath string, reqBody any, respBody any) error
+
+	// Put sends a PUT request to the controller.
+	Put(ctx context.Context, apiPath string, reqBody any, respBody any) error
+
+	// Version returns the version of the UniFi Controller API.
+	Version() string
+
+	// VersionContext returns the version of the UniFi Controller API using the supplied context, surfacing any fetch error instead of swallowing it.
+	VersionContext(ctx context.Context) (string, error)
+
+	// Internal returns the legacy ("Internal") UniFi Network API client.
+	Internal() InternalClient
+
+	// Official returns the Official UniFi OpenAPI client.
+	Official() official.Client
 }

--- a/unifi/client.go
+++ b/unifi/client.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/filipowm/go-unifi/unifi/official"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -87,6 +88,10 @@ type ClientConfig struct {
 	APIStyle       APIStyle
 	ValidationMode ValidationMode
 	Logger         Logger
+	// DisableOfficialAPI opts the client out of the Official UniFi OpenAPI:
+	// Official() operations then fail fast with ErrOfficialAPIDisabled and the
+	// capability probe is skipped entirely.
+	DisableOfficialAPI bool
 }
 
 // Credentials abstracts authentication credentials.
@@ -154,6 +159,18 @@ type client struct {
 	// a non-reentrant mutex and self-deadlock.
 	sysInfoMu sync.RWMutex
 	validator *validator
+
+	// officialDisabled mirrors ClientConfig.DisableOfficialAPI: when set, the
+	// capability gate fails fast with ErrOfficialAPIDisabled and never probes.
+	officialDisabled bool
+	// officialOnce lazily builds officialClient so its site-resolver cache
+	// survives across Official() calls.
+	officialOnce   sync.Once
+	officialClient official.Client
+	// officialReadyMu guards officialReady, which caches a successful capability
+	// probe so /v1/info is fetched at most once.
+	officialReadyMu sync.Mutex
+	officialReady   bool
 }
 
 var _ Client = &client{} // Ensure that client implements the Client interface. (compile-time check)
@@ -378,15 +395,16 @@ func newClientFromConfig(config *ClientConfig, v *validator) (*client, error) {
 	errorHandler := resolveErrorHandler(&cfg, log)
 	log.Tracef("Validation mode: %d", cfg.ValidationMode)
 	return &client{
-		baseURL:        baseURL,
-		timeout:        cfg.Timeout,
-		credentials:    credentials,
-		validationMode: cfg.ValidationMode,
-		http:           httpClient,
-		interceptors:   interceptors,
-		errorHandler:   errorHandler,
-		validator:      v,
-		Logger:         log,
+		baseURL:          baseURL,
+		timeout:          cfg.Timeout,
+		credentials:      credentials,
+		validationMode:   cfg.ValidationMode,
+		http:             httpClient,
+		interceptors:     interceptors,
+		errorHandler:     errorHandler,
+		validator:        v,
+		Logger:           log,
+		officialDisabled: cfg.DisableOfficialAPI,
 	}, nil
 }
 

--- a/unifi/client_mock.generated.go
+++ b/unifi/client_mock.generated.go
@@ -5,6 +5,7 @@ package unifi
 
 import (
 	"context"
+	"github.com/filipowm/go-unifi/unifi/official"
 	"io"
 	"sync"
 )
@@ -532,6 +533,9 @@ var _ Client = &ClientMock{}
 //			InfofFunc: func(format string, args ...any)  {
 //				panic("mock out the Infof method")
 //			},
+//			InternalFunc: func() InternalClient {
+//				panic("mock out the Internal method")
+//			},
 //			IsFeatureEnabledFunc: func(ctx context.Context, site string, name string) (bool, error) {
 //				panic("mock out the IsFeatureEnabled method")
 //			},
@@ -663,6 +667,9 @@ var _ Client = &ClientMock{}
 //			},
 //			LogoutContextFunc: func(ctx context.Context) error {
 //				panic("mock out the LogoutContext method")
+//			},
+//			OfficialFunc: func() official.Client {
+//				panic("mock out the Official method")
 //			},
 //			OverrideUserFingerprintFunc: func(ctx context.Context, site string, mac string, devIdOverride int) error {
 //				panic("mock out the OverrideUserFingerprint method")
@@ -1463,6 +1470,9 @@ type ClientMock struct {
 	// InfofFunc mocks the Infof method.
 	InfofFunc func(format string, args ...any)
 
+	// InternalFunc mocks the Internal method.
+	InternalFunc func() InternalClient
+
 	// IsFeatureEnabledFunc mocks the IsFeatureEnabled method.
 	IsFeatureEnabledFunc func(ctx context.Context, site string, name string) (bool, error)
 
@@ -1594,6 +1604,9 @@ type ClientMock struct {
 
 	// LogoutContextFunc mocks the LogoutContext method.
 	LogoutContextFunc func(ctx context.Context) error
+
+	// OfficialFunc mocks the Official method.
+	OfficialFunc func() official.Client
 
 	// OverrideUserFingerprintFunc mocks the OverrideUserFingerprint method.
 	OverrideUserFingerprintFunc func(ctx context.Context, site string, mac string, devIdOverride int) error
@@ -3295,6 +3308,9 @@ type ClientMock struct {
 			// Args is the args argument value.
 			Args []any
 		}
+		// Internal holds details about calls to the Internal method.
+		Internal []struct {
+		}
 		// IsFeatureEnabled holds details about calls to the IsFeatureEnabled method.
 		IsFeatureEnabled []struct {
 			// Ctx is the ctx argument value.
@@ -3592,6 +3608,9 @@ type ClientMock struct {
 		LogoutContext []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+		}
+		// Official holds details about calls to the Official method.
+		Official []struct {
 		}
 		// OverrideUserFingerprint holds details about calls to the OverrideUserFingerprint method.
 		OverrideUserFingerprint []struct {
@@ -4592,6 +4611,7 @@ type ClientMock struct {
 	lockGetWLANGroup                     sync.RWMutex
 	lockInfo                             sync.RWMutex
 	lockInfof                            sync.RWMutex
+	lockInternal                         sync.RWMutex
 	lockIsFeatureEnabled                 sync.RWMutex
 	lockKickUserByMAC                    sync.RWMutex
 	lockListAPGroup                      sync.RWMutex
@@ -4636,6 +4656,7 @@ type ClientMock struct {
 	lockLoginContext                     sync.RWMutex
 	lockLogout                           sync.RWMutex
 	lockLogoutContext                    sync.RWMutex
+	lockOfficial                         sync.RWMutex
 	lockOverrideUserFingerprint          sync.RWMutex
 	lockPost                             sync.RWMutex
 	lockPut                              sync.RWMutex
@@ -11329,6 +11350,33 @@ func (mock *ClientMock) InfofCalls() []struct {
 	return calls
 }
 
+// Internal calls InternalFunc.
+func (mock *ClientMock) Internal() InternalClient {
+	if mock.InternalFunc == nil {
+		panic("ClientMock.InternalFunc: method is nil but Client.Internal was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockInternal.Lock()
+	mock.calls.Internal = append(mock.calls.Internal, callInfo)
+	mock.lockInternal.Unlock()
+	return mock.InternalFunc()
+}
+
+// InternalCalls gets all the calls that were made to Internal.
+// Check the length with:
+//
+//	len(mockedClient.InternalCalls())
+func (mock *ClientMock) InternalCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockInternal.RLock()
+	calls = mock.calls.Internal
+	mock.lockInternal.RUnlock()
+	return calls
+}
+
 // IsFeatureEnabled calls IsFeatureEnabledFunc.
 func (mock *ClientMock) IsFeatureEnabled(ctx context.Context, site string, name string) (bool, error) {
 	if mock.IsFeatureEnabledFunc == nil {
@@ -12888,6 +12936,33 @@ func (mock *ClientMock) LogoutContextCalls() []struct {
 	mock.lockLogoutContext.RLock()
 	calls = mock.calls.LogoutContext
 	mock.lockLogoutContext.RUnlock()
+	return calls
+}
+
+// Official calls OfficialFunc.
+func (mock *ClientMock) Official() official.Client {
+	if mock.OfficialFunc == nil {
+		panic("ClientMock.OfficialFunc: method is nil but Client.Official was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockOfficial.Lock()
+	mock.calls.Official = append(mock.calls.Official, callInfo)
+	mock.lockOfficial.Unlock()
+	return mock.OfficialFunc()
+}
+
+// OfficialCalls gets all the calls that were made to Official.
+// Check the length with:
+//
+//	len(mockedClient.OfficialCalls())
+func (mock *ClientMock) OfficialCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockOfficial.RLock()
+	calls = mock.calls.Official
+	mock.lockOfficial.RUnlock()
 	return calls
 }
 

--- a/unifi/official/info.go
+++ b/unifi/official/info.go
@@ -1,0 +1,24 @@
+package official
+
+import (
+	"context"
+	"fmt"
+)
+
+// Info is the controller application info from GET /v1/info. ApplicationVersion
+// feeds the capability gate (the official API exists only from 10.1.68).
+type Info struct {
+	ApplicationVersion string `json:"applicationVersion"`
+}
+
+// GetInfo returns the controller application info.
+func (c *apiClient) GetInfo(ctx context.Context) (*Info, error) {
+	if err := c.check(ctx); err != nil {
+		return nil, err
+	}
+	var info Info
+	if err := c.doer.Get(ctx, c.path("/info"), nil, &info); err != nil {
+		return nil, fmt.Errorf("failed getting application info: %w", err)
+	}
+	return &info, nil
+}

--- a/unifi/official/official.go
+++ b/unifi/official/official.go
@@ -1,0 +1,69 @@
+// Package official is the Official UniFi OpenAPI (integration/v1) client surface.
+//
+// It imports nothing from the parent unifi package: the controller transport is
+// injected as a structural Doer, so the dependency is strictly one-way
+// (unifi -> official). *unifi.client satisfies Doer through its public
+// Get/Post/Put/Delete methods, and the capability check is injected as a Gate so
+// the version/auth gating policy stays in the parent package.
+package official
+
+import (
+	"context"
+	"sync"
+)
+
+// Doer is the transport seam: the subset of the UniFi client's public request
+// methods the official wrappers need. Wrappers pass FULL controller paths
+// (leading "/"), which the client resolves directly against its base URL,
+// bypassing the legacy API-path prefix.
+type Doer interface {
+	Get(ctx context.Context, apiPath string, reqBody, respBody any) error
+	Post(ctx context.Context, apiPath string, reqBody, respBody any) error
+	Put(ctx context.Context, apiPath string, reqBody, respBody any) error
+	Delete(ctx context.Context, apiPath string, reqBody, respBody any) error
+}
+
+// Gate reports whether the official API may be used; it is evaluated before
+// every operation and its error (unavailable/disabled) is returned verbatim.
+type Gate func(ctx context.Context) error
+
+// Client is the Official UniFi OpenAPI surface.
+type Client interface {
+	// GetInfo returns the controller application info (GET /v1/info).
+	GetInfo(ctx context.Context) (*Info, error)
+	// ListSites returns all local sites, auto-paginating the list envelope.
+	ListSites(ctx context.Context) ([]SiteOverview, error)
+	// ResolveSiteID maps a legacy site name (the Internal-API identifier) to its
+	// Official-API site UUID, caching the lookup.
+	ResolveSiteID(ctx context.Context, name string) (string, error)
+}
+
+// apiClient is the default Client implementation bound to an injected Doer.
+type apiClient struct {
+	doer     Doer
+	basePath string // integration/v1 prefix, e.g. /proxy/network/integration/v1
+	gate     Gate
+
+	// siteIDs caches internalReference (legacy site name) -> Official-API UUID.
+	mu      sync.RWMutex
+	siteIDs map[string]string
+}
+
+// New constructs an official Client bound to doer, with basePath the
+// integration/v1 prefix and gate the capability check run before each call.
+func New(doer Doer, basePath string, gate Gate) Client {
+	return &apiClient{doer: doer, basePath: basePath, gate: gate}
+}
+
+// check runs the capability gate (if any) before an operation.
+func (c *apiClient) check(ctx context.Context) error {
+	if c.gate == nil {
+		return nil
+	}
+	return c.gate(ctx)
+}
+
+// path joins the integration/v1 base prefix with a leading-slash sub-path.
+func (c *apiClient) path(sub string) string {
+	return c.basePath + sub
+}

--- a/unifi/official/official_test.go
+++ b/unifi/official/official_test.go
@@ -86,7 +86,7 @@ func TestListSitesAutoPaginates(t *testing.T) {
 	// 250 sites across two pages of <=200 — the resolver must walk both.
 	all := make([]SiteOverview, 0, 250)
 	for i := range 250 {
-		all = append(all, SiteOverview{Id: fmt.Sprintf("uuid-%d", i), InternalReference: fmt.Sprintf("site%d", i), Name: fmt.Sprintf("Site %d", i)})
+		all = append(all, SiteOverview{ID: fmt.Sprintf("uuid-%d", i), InternalReference: fmt.Sprintf("site%d", i), Name: fmt.Sprintf("Site %d", i)})
 	}
 
 	calls := 0
@@ -108,8 +108,8 @@ func TestResolveSiteIDCachesByInternalReference(t *testing.T) {
 	t.Parallel()
 	d := &fakeDoer{responses: map[string]any{
 		base + "/sites": sitePage(0, 2, []SiteOverview{
-			{Id: "uuid-default", InternalReference: "default", Name: "Default"},
-			{Id: "uuid-other", InternalReference: "other", Name: "Other"},
+			{ID: "uuid-default", InternalReference: "default", Name: "Default"},
+			{ID: "uuid-other", InternalReference: "other", Name: "Other"},
 		}),
 	}}
 	c := New(d, base, nil)

--- a/unifi/official/official_test.go
+++ b/unifi/official/official_test.go
@@ -1,0 +1,142 @@
+package official //nolint:testpackage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encode JSON-marshals v and unmarshals it into respBody, mimicking a transport
+// decoding a canned response.
+func encode(v, respBody any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, respBody)
+}
+
+// fakeDoer is a minimal in-memory Doer. It proves the official package needs
+// nothing from the parent unifi package: the transport is a plain structural
+// interface satisfied here by a test double.
+type fakeDoer struct {
+	responses map[string]any // path (sans query) -> value JSON-marshaled into respBody
+	calls     []string
+	err       error
+}
+
+func (f *fakeDoer) Get(_ context.Context, apiPath string, _, respBody any) error {
+	f.calls = append(f.calls, apiPath)
+	if f.err != nil {
+		return f.err
+	}
+	// Match on the path before any query string so paginated calls resolve.
+	key, _, _ := strings.Cut(apiPath, "?")
+	v, ok := f.responses[key]
+	if !ok {
+		return fmt.Errorf("no canned response for %s", apiPath)
+	}
+	return encode(v, respBody)
+}
+
+func (f *fakeDoer) Post(context.Context, string, any, any) error   { return nil }
+func (f *fakeDoer) Put(context.Context, string, any, any) error    { return nil }
+func (f *fakeDoer) Delete(context.Context, string, any, any) error { return nil }
+
+const base = "/proxy/network/integration/v1"
+
+func TestGetInfo(t *testing.T) {
+	t.Parallel()
+	d := &fakeDoer{responses: map[string]any{base + "/info": Info{ApplicationVersion: "10.1.68"}}}
+	c := New(d, base, nil)
+
+	info, err := c.GetInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "10.1.68", info.ApplicationVersion)
+	assert.Equal(t, []string{base + "/info"}, d.calls)
+}
+
+func TestGateBlocksOperations(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("blocked")
+	d := &fakeDoer{}
+	c := New(d, base, func(context.Context) error { return sentinel })
+
+	_, err := c.GetInfo(context.Background())
+	require.ErrorIs(t, err, sentinel)
+	assert.Empty(t, d.calls, "gate must short-circuit before any transport call")
+
+	_, err = c.ListSites(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+// sitePage builds one {offset,limit,count,totalCount,data} envelope.
+func sitePage(offset, total int, data []SiteOverview) page[SiteOverview] {
+	return page[SiteOverview]{Offset: offset, Limit: maxPageLimit, Count: len(data), TotalCount: total, Data: data}
+}
+
+func TestListSitesAutoPaginates(t *testing.T) {
+	t.Parallel()
+	// 250 sites across two pages of <=200 — the resolver must walk both.
+	all := make([]SiteOverview, 0, 250)
+	for i := range 250 {
+		all = append(all, SiteOverview{Id: fmt.Sprintf("uuid-%d", i), InternalReference: fmt.Sprintf("site%d", i), Name: fmt.Sprintf("Site %d", i)})
+	}
+
+	calls := 0
+	d := &pagingDoer{fn: func(_ string, respBody any) error {
+		start := calls * maxPageLimit
+		calls++
+		end := min(start+maxPageLimit, len(all))
+		return encode(sitePage(start, len(all), all[start:end]), respBody)
+	}}
+	c := New(d, base, nil)
+
+	sites, err := c.ListSites(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, sites, 250)
+	assert.Equal(t, 2, calls, "expected exactly two pages")
+}
+
+func TestResolveSiteIDCachesByInternalReference(t *testing.T) {
+	t.Parallel()
+	d := &fakeDoer{responses: map[string]any{
+		base + "/sites": sitePage(0, 2, []SiteOverview{
+			{Id: "uuid-default", InternalReference: "default", Name: "Default"},
+			{Id: "uuid-other", InternalReference: "other", Name: "Other"},
+		}),
+	}}
+	c := New(d, base, nil)
+
+	id, err := c.ResolveSiteID(context.Background(), "default")
+	require.NoError(t, err)
+	assert.Equal(t, "uuid-default", id)
+
+	// Second lookup is served from cache: no further transport call.
+	before := len(d.calls)
+	id2, err := c.ResolveSiteID(context.Background(), "other")
+	require.NoError(t, err)
+	assert.Equal(t, "uuid-other", id2)
+	assert.Len(t, d.calls, before, "cached lookup must not hit transport again")
+
+	_, err = c.ResolveSiteID(context.Background(), "ghost")
+	require.Error(t, err)
+}
+
+// pagingDoer drives ListSites pagination through a custom per-call function.
+type pagingDoer struct {
+	fn func(apiPath string, respBody any) error
+}
+
+func (p *pagingDoer) Get(_ context.Context, apiPath string, _, respBody any) error {
+	return p.fn(apiPath, respBody)
+}
+func (p *pagingDoer) Post(context.Context, string, any, any) error   { return nil }
+func (p *pagingDoer) Put(context.Context, string, any, any) error    { return nil }
+func (p *pagingDoer) Delete(context.Context, string, any, any) error { return nil }

--- a/unifi/official/official_test.go
+++ b/unifi/official/official_test.go
@@ -93,6 +93,10 @@ func TestListSitesAutoPaginates(t *testing.T) {
 	d := &pagingDoer{fn: func(_ string, respBody any) error {
 		start := calls * maxPageLimit
 		calls++
+		if start >= len(all) {
+			// Empty page signals end-of-list to listAll.
+			return encode(sitePage(start, len(all), nil), respBody)
+		}
 		end := min(start+maxPageLimit, len(all))
 		return encode(sitePage(start, len(all), all[start:end]), respBody)
 	}}
@@ -101,6 +105,7 @@ func TestListSitesAutoPaginates(t *testing.T) {
 	sites, err := c.ListSites(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, sites, 250)
+	// Two fetches: page 1 (200 items), page 2 (50 items, offset==totalCount -> stop).
 	assert.Equal(t, 2, calls, "expected exactly two pages")
 }
 
@@ -127,6 +132,86 @@ func TestResolveSiteIDCachesByInternalReference(t *testing.T) {
 
 	_, err = c.ResolveSiteID(context.Background(), "ghost")
 	require.Error(t, err)
+}
+
+// TestResolveSiteIDNotFoundSentinel asserts that ResolveSiteID wraps ErrSiteNotFound
+// so callers can match it with errors.Is.
+func TestResolveSiteIDNotFoundSentinel(t *testing.T) {
+	t.Parallel()
+	d := &fakeDoer{responses: map[string]any{
+		base + "/sites": sitePage(0, 1, []SiteOverview{
+			{ID: "uuid-default", InternalReference: "default", Name: "Default"},
+		}),
+	}}
+	c := New(d, base, nil)
+
+	_, err := c.ResolveSiteID(context.Background(), "ghost")
+	require.ErrorIs(t, err, ErrSiteNotFound, "not-found must be matchable with errors.Is")
+}
+
+// TestGetInfoTransportError asserts the error from the Doer is wrapped and
+// propagated by GetInfo.
+func TestGetInfoTransportError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("dial tcp: connection refused")
+	d := &fakeDoer{err: sentinel}
+	c := New(d, base, nil)
+
+	_, err := c.GetInfo(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestListSitesTransportError asserts the error from the Doer is wrapped and
+// propagated by ListSites.
+func TestListSitesTransportError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("connection reset")
+	d := &fakeDoer{err: sentinel}
+	c := New(d, base, nil)
+
+	_, err := c.ListSites(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestResolveSiteIDTransportError asserts the error from the Doer is wrapped
+// and propagated by ResolveSiteID.
+func TestResolveSiteIDTransportError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("timeout")
+	d := &fakeDoer{err: sentinel}
+	c := New(d, base, nil)
+
+	_, err := c.ResolveSiteID(context.Background(), "default")
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestListAllTerminatesOnEmptyPageWithHighTotalCount asserts listAll stops when
+// data dries up even when the server still reports a large totalCount.
+func TestListAllTerminatesOnEmptyPageWithHighTotalCount(t *testing.T) {
+	t.Parallel()
+	const reportedTotal = 999
+	realData := []SiteOverview{
+		{ID: "uuid-a", InternalReference: "a", Name: "A"},
+		{ID: "uuid-b", InternalReference: "b", Name: "B"},
+	}
+	calls := 0
+	d := &pagingDoer{fn: func(_ string, respBody any) error {
+		calls++
+		switch calls {
+		case 1:
+			// First page: return real data but lie about totalCount.
+			return encode(sitePage(0, reportedTotal, realData), respBody)
+		default:
+			// Second page: empty data — listAll must terminate here.
+			return encode(sitePage(len(realData), reportedTotal, nil), respBody)
+		}
+	}}
+	c := New(d, base, nil)
+
+	sites, err := c.ListSites(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, sites, len(realData))
+	assert.Equal(t, 2, calls, "must stop after the empty page, not spin to totalCount")
 }
 
 // pagingDoer drives ListSites pagination through a custom per-call function.

--- a/unifi/official/pagination.go
+++ b/unifi/official/pagination.go
@@ -1,0 +1,41 @@
+package official
+
+import (
+	"context"
+	"fmt"
+)
+
+// maxPageLimit is the largest page size the Official list endpoints accept
+// (the spec caps limit at 200; default is 25). We request the max to minimize
+// round-trips during auto-pagination.
+const maxPageLimit = 200
+
+// page is the {offset,limit,count,totalCount,data[]} envelope returned by the
+// paginated Official list endpoints.
+type page[T any] struct {
+	Offset     int `json:"offset"`
+	Limit      int `json:"limit"`
+	Count      int `json:"count"`
+	TotalCount int `json:"totalCount"`
+	Data       []T `json:"data"`
+}
+
+// listAll fetches every page of a paginated list endpoint and appends the
+// decoded items to out. It walks offset/limit until an empty page or the
+// reported totalCount is reached; an empty page always terminates so a
+// misreported totalCount can never spin forever.
+func listAll[T any](ctx context.Context, doer Doer, basePath string, out *[]T) error {
+	offset := 0
+	for {
+		var p page[T]
+		url := fmt.Sprintf("%s?offset=%d&limit=%d", basePath, offset, maxPageLimit)
+		if err := doer.Get(ctx, url, nil, &p); err != nil {
+			return err
+		}
+		*out = append(*out, p.Data...)
+		offset += len(p.Data)
+		if len(p.Data) == 0 || offset >= p.TotalCount {
+			return nil
+		}
+	}
+}

--- a/unifi/official/pagination.go
+++ b/unifi/official/pagination.go
@@ -21,9 +21,10 @@ type page[T any] struct {
 }
 
 // listAll fetches every page of a paginated list endpoint and appends the
-// decoded items to out. It walks offset/limit until an empty page or the
-// reported totalCount is reached; an empty page always terminates so a
-// misreported totalCount can never spin forever.
+// decoded items to out. It terminates on an empty page (definitive end-of-list)
+// or when accumulated equals totalCount (optimization to skip the trailing empty
+// probe). If the server underreports totalCount, the equal-count check is never
+// true and the loop falls through to the empty-page terminator.
 func listAll[T any](ctx context.Context, doer Doer, basePath string, out *[]T) error {
 	offset := 0
 	for {
@@ -34,7 +35,12 @@ func listAll[T any](ctx context.Context, doer Doer, basePath string, out *[]T) e
 		}
 		*out = append(*out, p.Data...)
 		offset += len(p.Data)
-		if len(p.Data) == 0 || offset >= p.TotalCount {
+		// Terminate on empty page (definitive end-of-list) or when accumulated equals
+		// totalCount (server accurately reported the total). The totalCount check is
+		// skipped when offset != totalCount — if the server underreported totalCount
+		// we'd stop before fetching all data, so we fall through to the empty-page
+		// terminator instead.
+		if len(p.Data) == 0 || offset == p.TotalCount {
 			return nil
 		}
 	}

--- a/unifi/official/sites.go
+++ b/unifi/official/sites.go
@@ -1,0 +1,60 @@
+package official
+
+import (
+	"context"
+	"fmt"
+)
+
+// SiteOverview is one entry from GET /v1/sites. Id is the Official-API site
+// UUID; InternalReference is the legacy site name used by the Internal API
+// (so callers keep passing the familiar name); Name is the display name.
+type SiteOverview struct {
+	Id                string `json:"id"`
+	InternalReference string `json:"internalReference"`
+	Name              string `json:"name"`
+}
+
+// ListSites returns all local sites, auto-paginating the list envelope.
+func (c *apiClient) ListSites(ctx context.Context) ([]SiteOverview, error) {
+	if err := c.check(ctx); err != nil {
+		return nil, err
+	}
+	var sites []SiteOverview
+	if err := listAll(ctx, c.doer, c.path("/sites"), &sites); err != nil {
+		return nil, fmt.Errorf("failed listing sites: %w", err)
+	}
+	return sites, nil
+}
+
+// ResolveSiteID maps a legacy site name (the Internal-API identifier, carried as
+// internalReference) to its Official-API site UUID. The full site list is cached
+// on first miss so repeated lookups avoid a round-trip.
+func (c *apiClient) ResolveSiteID(ctx context.Context, name string) (string, error) {
+	if id, ok := c.cachedSiteID(name); ok {
+		return id, nil
+	}
+	sites, err := c.ListSites(ctx)
+	if err != nil {
+		return "", err
+	}
+	c.mu.Lock()
+	if c.siteIDs == nil {
+		c.siteIDs = make(map[string]string, len(sites))
+	}
+	for _, s := range sites {
+		c.siteIDs[s.InternalReference] = s.Id
+	}
+	c.mu.Unlock()
+	if id, ok := c.cachedSiteID(name); ok {
+		return id, nil
+	}
+	return "", fmt.Errorf("site %q not found in official API", name)
+}
+
+// cachedSiteID returns the cached UUID for a legacy site name, if present.
+func (c *apiClient) cachedSiteID(name string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	id, ok := c.siteIDs[name]
+	return id, ok
+}

--- a/unifi/official/sites.go
+++ b/unifi/official/sites.go
@@ -2,8 +2,13 @@ package official
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+// ErrSiteNotFound is returned by ResolveSiteID when the given legacy site name
+// has no matching Official-API UUID in the full site list.
+var ErrSiteNotFound = errors.New("site not found")
 
 // SiteOverview is one entry from GET /v1/sites. ID is the Official-API site
 // UUID; InternalReference is the legacy site name used by the Internal API
@@ -48,7 +53,7 @@ func (c *apiClient) ResolveSiteID(ctx context.Context, name string) (string, err
 	if id, ok := c.cachedSiteID(name); ok {
 		return id, nil
 	}
-	return "", fmt.Errorf("site %q not found in official API", name)
+	return "", fmt.Errorf("%w: %q", ErrSiteNotFound, name)
 }
 
 // cachedSiteID returns the cached UUID for a legacy site name, if present.

--- a/unifi/official/sites.go
+++ b/unifi/official/sites.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 )
 
-// SiteOverview is one entry from GET /v1/sites. Id is the Official-API site
+// SiteOverview is one entry from GET /v1/sites. ID is the Official-API site
 // UUID; InternalReference is the legacy site name used by the Internal API
 // (so callers keep passing the familiar name); Name is the display name.
 type SiteOverview struct {
-	Id                string `json:"id"`
+	ID                string `json:"id"`
 	InternalReference string `json:"internalReference"`
 	Name              string `json:"name"`
 }
@@ -42,7 +42,7 @@ func (c *apiClient) ResolveSiteID(ctx context.Context, name string) (string, err
 		c.siteIDs = make(map[string]string, len(sites))
 	}
 	for _, s := range sites {
-		c.siteIDs[s.InternalReference] = s.Id
+		c.siteIDs[s.InternalReference] = s.ID
 	}
 	c.mu.Unlock()
 	if id, ok := c.cachedSiteID(name); ok {

--- a/unifi/official_surface.go
+++ b/unifi/official_surface.go
@@ -1,0 +1,69 @@
+package unifi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filipowm/go-unifi/unifi/official"
+	goversion "github.com/hashicorp/go-version"
+)
+
+// officialAPIMinVersion is the first controller version exposing the Official
+// UniFi OpenAPI (integration/v1).
+const officialAPIMinVersion = "10.1.68"
+
+// Internal returns the client itself as the InternalClient (legacy UniFi Network
+// API) surface. In 2.0.0 this is the canonical client; calling it documents
+// intent ahead of the 3.0.0 flip to the Official client as the default.
+func (c *client) Internal() InternalClient { //nolint:ireturn
+	return c
+}
+
+// Official returns the Official UniFi OpenAPI client bound to this client's
+// transport and gated on controller capability. The instance (and its
+// site-resolver cache) is built once and reused.
+func (c *client) Official() official.Client { //nolint:ireturn
+	c.officialOnce.Do(func() {
+		c.officialClient = official.New(c, integrationV1Path, c.officialAvailable)
+	})
+	return c.officialClient
+}
+
+// officialAvailable is the capability gate for the Official API. It fails fast
+// when opted out, requires a new-style controller with API-key auth, and
+// otherwise probes GET /v1/info once to confirm the version floor. A successful
+// probe is cached so subsequent operations skip it.
+func (c *client) officialAvailable(ctx context.Context) error {
+	if c.officialDisabled {
+		return ErrOfficialAPIDisabled
+	}
+	if c.apiPaths != &NewStyleAPI || !c.credentials.IsAPIKey() {
+		return fmt.Errorf("%w: requires a new-style controller with API-key authentication", ErrOfficialAPIUnavailable)
+	}
+
+	c.officialReadyMu.Lock()
+	defer c.officialReadyMu.Unlock()
+	if c.officialReady {
+		return nil
+	}
+
+	var info official.Info
+	if err := c.Get(ctx, integrationV1Path+"/info", nil, &info); err != nil {
+		return fmt.Errorf("%w: %w", ErrOfficialAPIUnavailable, err)
+	}
+	if !versionAtLeast(info.ApplicationVersion, officialAPIMinVersion) {
+		return fmt.Errorf("%w: controller version %q is below the required %s", ErrOfficialAPIUnavailable, info.ApplicationVersion, officialAPIMinVersion)
+	}
+	c.officialReady = true
+	return nil
+}
+
+// versionAtLeast reports whether have is a parseable version >= minVersion. An
+// unparseable have is treated as below the floor.
+func versionAtLeast(have, minVersion string) bool {
+	h, err := goversion.NewVersion(have)
+	if err != nil {
+		return false
+	}
+	return h.GreaterThanOrEqual(goversion.Must(goversion.NewVersion(minVersion)))
+}

--- a/unifi/official_surface_test.go
+++ b/unifi/official_surface_test.go
@@ -85,6 +85,45 @@ func TestOfficialGateDisabled(t *testing.T) {
 	require.ErrorIs(t, err, ErrOfficialAPIDisabled)
 }
 
+// TestOfficialGateProbeIsCached asserts the at-most-once /v1/info contract: the
+// capability probe fires exactly once even across multiple Official() operations.
+// GetInfo hits /v1/info twice on a cold cache (probe + real call); the second
+// operation (ResolveSiteID) must reuse the cached gate result and not re-probe.
+func TestOfficialGateProbeIsCached(t *testing.T) {
+	t.Parallel()
+	cs := newControllerServer(t,
+		infoRoute("10.1.68"),
+		route{officialSitesPath, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"offset":0,"limit":200,"count":1,"totalCount":1,"data":[` +
+				`{"id":"uuid-default","internalReference":"default","name":"Default"}]}`))
+		}},
+	)
+	c := cs.client()
+
+	// First operation: gate probe + real GetInfo both hit /v1/info (two total).
+	_, err := c.Official().GetInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, cs.countRequestsTo(officialInfoPath), "cold GetInfo: probe + real call = 2 hits on /v1/info")
+
+	// Second operation: gate must short-circuit (officialReady=true), no new probe.
+	_, err = c.Official().ResolveSiteID(context.Background(), "default")
+	require.NoError(t, err)
+	assert.Equal(t, 2, cs.countRequestsTo(officialInfoPath), "subsequent op must not re-probe /v1/info")
+}
+
+// TestOfficialGateUnavailableEndpointAbsent covers the realistic old-controller
+// case where integration/v1 is entirely absent (404) — the probe fails and the
+// error wraps ErrOfficialAPIUnavailable.
+func TestOfficialGateUnavailableEndpointAbsent(t *testing.T) {
+	t.Parallel()
+	// No routes registered: unmatched /v1/info returns 404, exercising the probe-error path.
+	cs := newControllerServer(t)
+	c := cs.client()
+
+	_, err := c.Official().GetInfo(context.Background())
+	require.ErrorIs(t, err, ErrOfficialAPIUnavailable)
+}
+
 // TestInternalAccessorReturnsResourceSurface proves client.Internal() exposes the
 // same resource CRUD the top-level client embeds.
 func TestInternalAccessorReturnsResourceSurface(t *testing.T) {

--- a/unifi/official_surface_test.go
+++ b/unifi/official_surface_test.go
@@ -124,6 +124,30 @@ func TestOfficialGateUnavailableEndpointAbsent(t *testing.T) {
 	require.ErrorIs(t, err, ErrOfficialAPIUnavailable)
 }
 
+// TestVersionAtLeastUnparseable asserts that an empty or garbage version is treated
+// as below the floor (fail-closed) so the gate rejects unknown controller builds.
+func TestVersionAtLeastUnparseable(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{"", "not-a-version", "???"} {
+		assert.False(t, versionAtLeast(v, officialAPIMinVersion), "unparseable %q must be below floor", v)
+	}
+}
+
+// TestOfficialGateUnavailableNewStyleUserPass asserts that a new-style controller
+// with user/password auth (no API key) returns ErrOfficialAPIUnavailable.
+func TestOfficialGateUnavailableNewStyleUserPass(t *testing.T) {
+	t.Parallel()
+	c := newOfflineClient(t, &ClientConfig{
+		URL:      testUrl,
+		User:     "u",
+		Password: "p",
+		APIStyle: APIStyleNew,
+	})
+
+	_, err := c.Official().GetInfo(context.Background())
+	require.ErrorIs(t, err, ErrOfficialAPIUnavailable)
+}
+
 // TestInternalAccessorReturnsResourceSurface proves client.Internal() exposes the
 // same resource CRUD the top-level client embeds.
 func TestInternalAccessorReturnsResourceSurface(t *testing.T) {

--- a/unifi/official_surface_test.go
+++ b/unifi/official_surface_test.go
@@ -1,0 +1,99 @@
+package unifi //nolint:testpackage
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	officialInfoPath  = integrationV1Path + "/info"
+	officialSitesPath = integrationV1Path + "/sites"
+)
+
+// infoRoute serves GET /v1/info with the given application version.
+func infoRoute(version string) route {
+	return route{officialInfoPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"applicationVersion":"` + version + `"}`))
+	}}
+}
+
+func TestOfficialGetInfo(t *testing.T) {
+	t.Parallel()
+	cs := newControllerServer(t, infoRoute("10.1.68"))
+	c := cs.client()
+
+	info, err := c.Official().GetInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "10.1.68", info.ApplicationVersion)
+}
+
+func TestOfficialResolveSiteID(t *testing.T) {
+	t.Parallel()
+	cs := newControllerServer(t,
+		infoRoute("10.1.68"),
+		route{officialSitesPath, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"offset":0,"limit":200,"count":2,"totalCount":2,"data":[` +
+				`{"id":"uuid-default","internalReference":"default","name":"Default"},` +
+				`{"id":"uuid-lab","internalReference":"lab","name":"Lab"}]}`))
+		}},
+	)
+	c := cs.client()
+
+	id, err := c.Official().ResolveSiteID(context.Background(), "lab")
+	require.NoError(t, err)
+	assert.Equal(t, "uuid-lab", id)
+}
+
+func TestOfficialGateUnavailableBelowVersionFloor(t *testing.T) {
+	t.Parallel()
+	cs := newControllerServer(t, infoRoute("10.1.67"))
+	c := cs.client()
+
+	_, err := c.Official().GetInfo(context.Background())
+	require.ErrorIs(t, err, ErrOfficialAPIUnavailable)
+}
+
+func TestOfficialGateUnavailableOldStyle(t *testing.T) {
+	t.Parallel()
+	// Old-style controllers are unsupported for the Official API; user/pass auth
+	// is required there since API-key + old-style is rejected at construction.
+	c := newOfflineClient(t, &ClientConfig{
+		URL:      testUrl,
+		User:     "u",
+		Password: "p",
+		APIStyle: APIStyleOld,
+	})
+
+	_, err := c.Official().GetInfo(context.Background())
+	require.ErrorIs(t, err, ErrOfficialAPIUnavailable)
+}
+
+func TestOfficialGateDisabled(t *testing.T) {
+	t.Parallel()
+	c := newOfflineClient(t, &ClientConfig{
+		URL:                testUrl,
+		APIKey:             "test-key",
+		APIStyle:           APIStyleNew,
+		DisableOfficialAPI: true,
+	})
+
+	_, err := c.Official().GetInfo(context.Background())
+	require.ErrorIs(t, err, ErrOfficialAPIDisabled)
+}
+
+// TestInternalAccessorReturnsResourceSurface proves client.Internal() exposes the
+// same resource CRUD the top-level client embeds.
+func TestInternalAccessorReturnsResourceSurface(t *testing.T) {
+	t.Parallel()
+	cs := newControllerServer(t)
+	c := cs.client()
+
+	require.NotNil(t, c.Internal())
+	// Compile-time proof the top-level client also satisfies InternalClient (the
+	// embedded resource CRUD surface is reachable both ways).
+	var _ InternalClient = c
+}

--- a/unifi/testhelpers_test.go
+++ b/unifi/testhelpers_test.go
@@ -155,6 +155,19 @@ func (cs *controllerServer) requestCount() int {
 	return len(cs.requests)
 }
 
+// countRequestsTo returns how many recorded requests matched path, read under mu.
+func (cs *controllerServer) countRequestsTo(path string) int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	n := 0
+	for _, r := range cs.requests {
+		if r.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
 // apiPath returns the full new-style request path for a controller-relative path
 // (the same join the client performs), e.g. "s/default/rest/user" ->
 // "/proxy/network/api/s/default/rest/user".

--- a/unifi/unifi_errors.go
+++ b/unifi/unifi_errors.go
@@ -12,6 +12,15 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
+// ErrOfficialAPIUnavailable is returned when the Official UniFi OpenAPI cannot be
+// used against this controller: an old-style (classic) controller, non-API-key
+// auth, or a controller version below 10.1.68.
+var ErrOfficialAPIUnavailable = errors.New("official API unavailable")
+
+// ErrOfficialAPIDisabled is returned when the Official API has been explicitly
+// opted out via ClientConfig.DisableOfficialAPI.
+var ErrOfficialAPIDisabled = errors.New("official API disabled")
+
 // maxErrorBodySize caps how much of an error response body we buffer before
 // decoding, so a hostile or runaway error page (e.g. a multi-megabyte HTML
 // gateway response) can never exhaust memory while we build a ServerError.


### PR DESCRIPTION
Closes (manually, after merge into feat/2.0.0) #119. Part of epic #117.

## What

Establishes the **architecture-first runtime seam** for the Official (OpenAPI `integration/v1`) API as a sibling surface to the existing Internal API, landing a real compiling vertical (`info` + `sites`) with hand-written types — no OpenAPI codegen yet. Internal stays canonical at the client root in 2.0.0; Official is opt-in via `client.Official()` (root flips to Official in 3.0.0).

- New package `unifi/official` with a **one-way** dependency (`unifi → official`) via a structural `Doer` interface — `*unifi.client` satisfies it; no import cycle.
- `integrationV1Path = "/proxy/network/integration/v1"`; `APIStyle` unchanged (Official is a capability on new-style, not a 4th enum).
- Sentinels `ErrOfficialAPIUnavailable` / `ErrOfficialAPIDisabled`; package-local `ErrSiteNotFound`.
- Capability gate `officialAvailable(ctx)` = new-style + API-key + controller `≥10.1.68`; `ClientConfig.DisableOfficialAPI` fails fast (no probe).
- `Internal()` / `Official()` accessors (`official_surface.go`).
- Hand-typed info+sites vertical: `GET /v1/info`, paginated `GET /v1/sites` with `{offset,limit,count,totalCount,data[]}` envelope decode + auto-pagination + cached name→UUID resolver keyed on `internalReference`.
- Codegen interface split (`codegen/clients.go` + `client.go.tmpl`): generated `Client` now embeds `InternalClient` (all resource CRUD) + transport/lifecycle + the new accessors. `client.generated.go` + `client_mock.generated.go` regenerated.

## ⚠️ Breaking changes (see `docs/2.0.0/breaking_changes.md`)

1. **`Client` interface split** into embedded `InternalClient` + `Internal()`/`Official()` accessors. Source-compatible for call sites (`client.GetNetwork(...)` still works); third-party `Client` implementations must add the accessors (moq mock regenerated automatically).
2. **Official API unavailable on classic/old-style controllers** (API-key-only new-style required) → `ErrOfficialAPIUnavailable`; `<10.1.68` → `ErrOfficialAPIUnavailable`; opt-out → `ErrOfficialAPIDisabled`.

## Edge cases handled

Version floor 10.1.68; classic/old-style unsupported; site UUID-vs-name resolver via `internalReference`; paginated envelope (default 25 / max 200) with empty-page terminator robust to misreported `totalCount`; flat Official error envelope already mapped by the v2 `DefaultResponseErrorHandler` (verified, no change).

## Quality gate (ran inside a Claude Code workflow)

Implement+Verify (Opus) → architect ‖ test-lead review (Opus) → remediate → re-verify. **Both reviewers APPROVE.** `go build` / full `go test` / `golangci-lint run` green; `unifi/official` at **100% coverage**. Generated files regenerated (never hand-edited).

## Deferred (nits, non-blocking)

- `GetInfo` cold-cache double `/v1/info` round-trip (fires once, documented).
- `Doer` declares `Post/Put/Delete` (forward-looking transport seam; trimming would be a breaking interface change).
- Sentinels split across `unifi` / `official` packages (forced by the one-way dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)