### PR TITLE
feat(codegen): track Internal and Official API versions separately (#136)

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,13 +32,12 @@ jobs:
           path: "./.unifi-version"
           trim: "true"
 
-      # Surface the committed Official OpenAPI snapshot version (its filename) so
-      # the PR body shows which spec the Official surface was regenerated from.
-      - name: "Read Official OpenAPI snapshot version"
-        id: "openapi_version"
-        run: |
-          latest=$(ls -t codegen/openapi/integration-*.json | head -n1)
-          echo "version=$(basename "$latest" .json | sed -E 's/integration-//')" >> "$GITHUB_OUTPUT"
+      - name: "Read Official API version marker"
+        id: "official_version"
+        uses: "juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18"  # v1.1.8
+        with:
+          path: "./.unifi-version-official"
+          trim: "true"
 
       # TODO: Automatically merge the PR if tests pass.
       - uses: "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1"  # v8.1.1
@@ -50,6 +49,6 @@ jobs:
             Automated regeneration via `go generate unifi/codegen.go`.
 
             - Internal resources → controller `${{ steps.unifi_version.outputs.content }}`
-            - Official OpenAPI surface (models + wrappers + interface + mock) → spec `${{ steps.openapi_version.outputs.version }}`
+            - Official OpenAPI surface (models + wrappers + interface + mock) → spec `${{ steps.official_version.outputs.content }}`
 
             Review the `codegen/openapi/integration-*.json` diff for the spec delta.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ unifi/                  Single Go package: client + all resource types
   official/             Official UniFi OpenAPI (integration/v1) client — imports NOTHING from unifi
 codegen/                Code-generation pipeline (see codegen/CLAUDE.md)
 docs/                   Documentation
-.unifi-version          Supported controller version marker (e.g. 9.3.45)
+.unifi-version          Internal (legacy) API controller version marker (e.g. 9.5.21)
+.unifi-version-official Official OpenAPI (integration/v1) spec version marker (e.g. 10.1.78)
 ```
 
 ## Style

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UniFi Go SDK
 
 ![GitHub Release](https://img.shields.io/github/v/release/filipowm/go-unifi)
-![Supported UniFi Controller Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version&search=(.*)%3F&logo=ubiquiti&label=Supported%20UniFi%20Controller%20Version&color=yellow)
+![Supported Internal API Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version&search=(.*)%3F&logo=ubiquiti&label=Supported%20Internal%20API%20Version&color=yellow)
 ![Supported Official API Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version-official&search=(.*)%3F&logo=ubiquiti&label=Supported%20Official%20API%20Version&color=blue)
 [![Docs](https://img.shields.io/badge/docs-reference-blue)](https://github.com/filipowm/go-unifi/blob/main/docs/readme.md)
 [![GoDoc](https://godoc.org/github.com/filipowm/go-unifi?status.svg)](https://godoc.org/github.com/filipowm/go-unifi)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![GitHub Release](https://img.shields.io/github/v/release/filipowm/go-unifi)
 ![Supported UniFi Controller Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version&search=(.*)%3F&logo=ubiquiti&label=Supported%20UniFi%20Controller%20Version&color=yellow)
+![Supported Official API Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version-official&search=(.*)%3F&logo=ubiquiti&label=Supported%20Official%20API%20Version&color=blue)
 [![Docs](https://img.shields.io/badge/docs-reference-blue)](https://github.com/filipowm/go-unifi/blob/main/docs/readme.md)
 [![GoDoc](https://godoc.org/github.com/filipowm/go-unifi?status.svg)](https://godoc.org/github.com/filipowm/go-unifi)
 ![GitHub branch check runs](https://img.shields.io/github/check-runs/filipowm/go-unifi/main)
@@ -23,7 +24,7 @@ Check out the detailed [documentation](docs/readme.md) for more information.
 
 ## Supported UniFi Controller Versions
 
-Any version after 5.12.35 is supported as of now. **Latest version: 9.5.21**.
+Any version after 5.12.35 is supported as of now. **Latest Internal API version: 9.5.21; Latest Official API version: 10.1.78**.
 The SDK is updated daily to track the latest UniFi Controller versions.
 If you encounter any issues with the latest UniFi Controller version, please open an issue.
 

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -222,7 +222,7 @@ func generate(opts options) error {
 		return err
 	}
 
-	if err = writeVersionArtifacts(unifiVersion, outDir, logger); err != nil {
+	if err = writeVersionArtifacts(unifiVersion, officialVersion, outDir, logger); err != nil {
 		return err
 	}
 
@@ -230,17 +230,21 @@ func generate(opts options) error {
 	return nil
 }
 
-// writeVersionArtifacts writes version.generated.go beside the resources and the
-// .unifi-version marker at the parent of outDir (the unifi/ package), so the
-// marker tracks the generated code regardless of cwd.
-func writeVersionArtifacts(unifiVersion *UnifiVersion, outDir string, logger Logger) error {
+// writeVersionArtifacts writes version.generated.go beside the resources and both
+// .unifi-version (Internal) and .unifi-version-official (Official) markers at the
+// parent of outDir (the repo root), so both markers track the generated code
+// regardless of cwd.
+func writeVersionArtifacts(unifiVersion *UnifiVersion, officialVersion *UnifiVersion, outDir string, logger Logger) error {
 	logger.Infof("Writing version file...")
-	if err := writeVersionFile(unifiVersion.Version, outDir); err != nil {
+	if err := writeVersionFile(unifiVersion.Version, officialVersion.Version, outDir); err != nil {
 		return fmt.Errorf("failed to write version file to %s: %w", outDir, err)
 	}
 	markerDir := filepath.Dir(outDir)
 	if err := writeVersionRepoMarkerFile(unifiVersion.Version, markerDir); err != nil {
-		return fmt.Errorf("failed to write version file to %s: %w", markerDir, err)
+		return fmt.Errorf("failed to write internal version marker to %s: %w", markerDir, err)
+	}
+	if err := writeOfficialVersionRepoMarkerFile(officialVersion.Version, markerDir); err != nil {
+		return fmt.Errorf("failed to write official version marker to %s: %w", markerDir, err)
 	}
 	return nil
 }

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -240,10 +240,10 @@ func writeVersionArtifacts(internalVersion *UnifiVersion, officialVersion *Unifi
 		return fmt.Errorf("failed to write version file to %s: %w", outDir, err)
 	}
 	markerDir := filepath.Dir(outDir)
-	if err := writeVersionRepoMarkerFile(internalVersion.Version, markerDir); err != nil {
+	if err := writeVersionMarker(internalVersion.Version, markerDir, ".unifi-version"); err != nil {
 		return fmt.Errorf("failed to write internal version marker to %s: %w", markerDir, err)
 	}
-	if err := writeOfficialVersionRepoMarkerFile(officialVersion.Version, markerDir); err != nil {
+	if err := writeVersionMarker(officialVersion.Version, markerDir, ".unifi-version-official"); err != nil {
 		return fmt.Errorf("failed to write official version marker to %s: %w", markerDir, err)
 	}
 	return nil

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -171,13 +171,13 @@ func generate(opts options) error {
 	logger := orDefaultLogger(opts.logger)
 
 	p := NewUnifiVersionProvider(opts.firmwareUpdateApi)
-	unifiVersion, officialVersion, err := resolveVersions(p, opts)
+	internalVersion, officialVersion, err := resolveVersions(p, opts)
 	if err != nil {
 		return err
 	}
 
-	logger.Infof("UniFi Controller version: %s", unifiVersion.Version)
-	logger.Infof("UniFi Controller download URL: %s", unifiVersion.DownloadUrl.String())
+	logger.Infof("UniFi Controller version: %s", internalVersion.Version)
+	logger.Infof("UniFi Controller download URL: %s", internalVersion.DownloadUrl.String())
 	logger.Infof("Official-API spec version: %s", officialVersion.Version)
 
 	wd, err := os.Getwd()
@@ -185,7 +185,7 @@ func generate(opts options) error {
 		return fmt.Errorf("unable to determine working directory: %w", err)
 	}
 	versionBaseDir := resolveDir(wd, opts.versionBaseDir)
-	structuresDir, err := downloadGenerationInputs(unifiVersion, officialVersion, versionBaseDir, logger)
+	structuresDir, err := downloadGenerationInputs(internalVersion, officialVersion, versionBaseDir, logger)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func generate(opts options) error {
 		return err
 	}
 
-	if err = writeVersionArtifacts(unifiVersion, officialVersion, outDir, logger); err != nil {
+	if err = writeVersionArtifacts(internalVersion, officialVersion, outDir, logger); err != nil {
 		return err
 	}
 
@@ -234,13 +234,13 @@ func generate(opts options) error {
 // .unifi-version (Internal) and .unifi-version-official (Official) markers at the
 // parent of outDir (the repo root), so both markers track the generated code
 // regardless of cwd.
-func writeVersionArtifacts(unifiVersion *UnifiVersion, officialVersion *UnifiVersion, outDir string, logger Logger) error {
+func writeVersionArtifacts(internalVersion *UnifiVersion, officialVersion *UnifiVersion, outDir string, logger Logger) error {
 	logger.Infof("Writing version file...")
-	if err := writeVersionFile(unifiVersion.Version, officialVersion.Version, outDir); err != nil {
+	if err := writeVersionFile(internalVersion.Version, officialVersion.Version, outDir); err != nil {
 		return fmt.Errorf("failed to write version file to %s: %w", outDir, err)
 	}
 	markerDir := filepath.Dir(outDir)
-	if err := writeVersionRepoMarkerFile(unifiVersion.Version, markerDir); err != nil {
+	if err := writeVersionRepoMarkerFile(internalVersion.Version, markerDir); err != nil {
 		return fmt.Errorf("failed to write internal version marker to %s: %w", markerDir, err)
 	}
 	if err := writeOfficialVersionRepoMarkerFile(officialVersion.Version, markerDir); err != nil {

--- a/codegen/main_test.go
+++ b/codegen/main_test.go
@@ -178,15 +178,22 @@ func TestGenerateLatest(t *testing.T) {
 	r.NoError(err)
 	assert.NotEmptyf(t, files, "output dir '%s' should not be empty", opts.outputDir)
 
-	// Marker is written beside outDir (at root), not in cwd, and matches version.generated.go.
+	// Internal marker written beside outDir (at root), and matches version.generated.go.
 	marker, err := os.ReadFile(filepath.Join(root, ".unifi-version"))
 	r.NoError(err)
-	version := strings.TrimSpace(string(marker))
-	r.NotEmpty(version)
+	internalVersion := strings.TrimSpace(string(marker))
+	r.NotEmpty(internalVersion)
 
 	versionGo, err := os.ReadFile(filepath.Join(opts.outputDir, "version.generated.go"))
 	r.NoError(err)
-	assert.Contains(t, string(versionGo), `"`+version+`"`, "marker must match version.generated.go")
+	assert.Contains(t, string(versionGo), `"`+internalVersion+`"`, "internal marker must match version.generated.go UnifiVersion")
+
+	// Official marker is also written beside outDir and its const is in version.generated.go.
+	officialMarker, err := os.ReadFile(filepath.Join(root, ".unifi-version-official"))
+	r.NoError(err)
+	officialVersion := strings.TrimSpace(string(officialMarker))
+	r.NotEmpty(officialVersion)
+	assert.Contains(t, string(versionGo), `OfficialAPIVersion = "`+officialVersion+`"`, "official marker must match version.generated.go OfficialAPIVersion")
 
 	// Assert that generate() commits the Official OpenAPI spec snapshot.
 	specGlob := filepath.Join(opts.versionBaseDir, "openapi", "integration-*.json")

--- a/codegen/version.go
+++ b/codegen/version.go
@@ -183,12 +183,9 @@ const OfficialAPIVersion = %q
 	return err
 }
 
-func writeVersionRepoMarkerFile(version *version.Version, outDir string) error {
-	versionRepoMarker := []byte(version.Core().String())
-	return os.WriteFile(filepath.Join(outDir, ".unifi-version"), versionRepoMarker, 0o644) //nolint:gosec
-}
-
-func writeOfficialVersionRepoMarkerFile(version *version.Version, outDir string) error {
-	versionRepoMarker := []byte(version.Core().String())
-	return os.WriteFile(filepath.Join(outDir, ".unifi-version-official"), versionRepoMarker, 0o644) //nolint:gosec
+// writeVersionMarker writes a plain-text version marker (core version, no
+// trailing newline) to outDir/filename — used for both .unifi-version (Internal)
+// and .unifi-version-official (Official).
+func writeVersionMarker(version *version.Version, outDir, filename string) error {
+	return os.WriteFile(filepath.Join(outDir, filename), []byte(version.Core().String()), 0o644) //nolint:gosec
 }

--- a/codegen/version.go
+++ b/codegen/version.go
@@ -163,14 +163,16 @@ func legacyFieldsDir(baseDir string, ver *version.Version) string {
 	return filepath.Join(baseDir, fmt.Sprintf("v%s", ver.Core()))
 }
 
-func writeVersionFile(version *version.Version, outDir string) error {
+func writeVersionFile(internalVersion *version.Version, officialVersion *version.Version, outDir string) error {
 	versionGo := fmt.Appendf(nil, `
 // Generated code. DO NOT EDIT.
 
 package unifi
 
 const UnifiVersion = %q
-`, version.Core())
+
+const OfficialAPIVersion = %q
+`, internalVersion.Core(), officialVersion.Core())
 
 	versionGo, err := format.Source(versionGo)
 	if err != nil {
@@ -184,4 +186,9 @@ const UnifiVersion = %q
 func writeVersionRepoMarkerFile(version *version.Version, outDir string) error {
 	versionRepoMarker := []byte(version.Core().String())
 	return os.WriteFile(filepath.Join(outDir, ".unifi-version"), versionRepoMarker, 0o644) //nolint:gosec
+}
+
+func writeOfficialVersionRepoMarkerFile(version *version.Version, outDir string) error {
+	versionRepoMarker := []byte(version.Core().String())
+	return os.WriteFile(filepath.Join(outDir, ".unifi-version-official"), versionRepoMarker, 0o644) //nolint:gosec
 }

--- a/codegen/version.go
+++ b/codegen/version.go
@@ -187,5 +187,9 @@ const OfficialAPIVersion = %q
 // trailing newline) to outDir/filename — used for both .unifi-version (Internal)
 // and .unifi-version-official (Official).
 func writeVersionMarker(version *version.Version, outDir, filename string) error {
-	return os.WriteFile(filepath.Join(outDir, filename), []byte(version.Core().String()), 0o644) //nolint:gosec
+	path := filepath.Join(outDir, filename)
+	if err := os.WriteFile(path, []byte(version.Core().String()), 0o644); err != nil { //nolint:gosec
+		return fmt.Errorf("write version marker %s: %w", path, err)
+	}
+	return nil
 }

--- a/codegen/version_test.go
+++ b/codegen/version_test.go
@@ -309,7 +309,7 @@ func TestWriteVersionRepoMarkerFile(t *testing.T) {
 	v, err := version.NewVersion("7.3.83")
 	require.NoError(t, err)
 
-	err = writeVersionRepoMarkerFile(v, tmpDir)
+	err = writeVersionMarker(v, tmpDir, ".unifi-version")
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version"))
@@ -344,7 +344,7 @@ func TestWriteVersionRepoMarkerFile_InvalidDir(t *testing.T) {
 	v, err := version.NewVersion("7.3.83")
 	require.NoError(t, err)
 
-	err = writeVersionRepoMarkerFile(v, "/nonexistent/directory")
+	err = writeVersionMarker(v, "/nonexistent/directory", ".unifi-version")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "no such file or directory")
 }
@@ -414,7 +414,7 @@ func TestWriteVersionRepoMarkerFile_Permissions(t *testing.T) {
 	v, err := version.NewVersion("7.3.83")
 	require.NoError(t, err)
 
-	err = writeVersionRepoMarkerFile(v, readOnlyDir)
+	err = writeVersionMarker(v, readOnlyDir, ".unifi-version")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "permission denied")
 }
@@ -427,7 +427,7 @@ func TestWriteOfficialVersionRepoMarkerFile(t *testing.T) {
 	v, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	err = writeOfficialVersionRepoMarkerFile(v, tmpDir)
+	err = writeVersionMarker(v, tmpDir, ".unifi-version-official")
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version-official"))
@@ -441,7 +441,7 @@ func TestWriteOfficialVersionRepoMarkerFile_InvalidDir(t *testing.T) {
 	v, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	err = writeOfficialVersionRepoMarkerFile(v, "/nonexistent/directory")
+	err = writeVersionMarker(v, "/nonexistent/directory", ".unifi-version-official")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "no such file or directory")
 }
@@ -461,7 +461,7 @@ func TestWriteOfficialVersionRepoMarkerFile_Permissions(t *testing.T) {
 	v, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	err = writeOfficialVersionRepoMarkerFile(v, readOnlyDir)
+	err = writeVersionMarker(v, readOnlyDir, ".unifi-version-official")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "permission denied")
 }
@@ -478,8 +478,8 @@ func TestWriteVersionRepoMarkersIndependent(t *testing.T) {
 	official, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	require.NoError(t, writeVersionRepoMarkerFile(internal, tmpDir))
-	require.NoError(t, writeOfficialVersionRepoMarkerFile(official, tmpDir))
+	require.NoError(t, writeVersionMarker(internal, tmpDir, ".unifi-version"))
+	require.NoError(t, writeVersionMarker(official, tmpDir, ".unifi-version-official"))
 
 	internalContent, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version"))
 	require.NoError(t, err)

--- a/codegen/version_test.go
+++ b/codegen/version_test.go
@@ -269,15 +269,36 @@ func TestWriteVersionFile(t *testing.T) {
 	a := assert.New(t)
 
 	tmpDir := t.TempDir()
-	v, err := version.NewVersion("7.3.83")
+	internal, err := version.NewVersion("7.3.83")
+	require.NoError(t, err)
+	official, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	err = writeVersionFile(v, tmpDir)
+	err = writeVersionFile(internal, official, tmpDir)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(tmpDir, "version.generated.go"))
 	require.NoError(t, err)
 	a.Contains(string(content), `const UnifiVersion = "7.3.83"`)
+	a.Contains(string(content), `const OfficialAPIVersion = "10.1.78"`)
+}
+
+func TestWriteVersionFile_BothConstsDistinct(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	internal, err := version.NewVersion("9.5.21")
+	require.NoError(t, err)
+	official, err := version.NewVersion("10.1.78")
+	require.NoError(t, err)
+
+	require.NoError(t, writeVersionFile(internal, official, tmpDir))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "version.generated.go"))
+	require.NoError(t, err)
+	// Internal and Official versions legitimately diverge — verify each pin is written.
+	assert.Contains(t, string(content), `const UnifiVersion = "9.5.21"`)
+	assert.Contains(t, string(content), `const OfficialAPIVersion = "10.1.78"`)
 }
 
 func TestWriteVersionRepoMarkerFile(t *testing.T) {
@@ -307,10 +328,12 @@ func TestLatestUnifiVersion_InvalidUrl(t *testing.T) {
 func TestWriteVersionFile_InvalidDir(t *testing.T) {
 	t.Parallel()
 
-	v, err := version.NewVersion("7.3.83")
+	internal, err := version.NewVersion("7.3.83")
+	require.NoError(t, err)
+	official, err := version.NewVersion("10.1.78")
 	require.NoError(t, err)
 
-	err = writeVersionFile(v, "/nonexistent/directory")
+	err = writeVersionFile(internal, official, "/nonexistent/directory")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "no such file or directory")
 }
@@ -362,15 +385,18 @@ func TestWriteVersionFile_EmptyVersion(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	v, err := version.NewVersion("0.0.0")
+	internal, err := version.NewVersion("0.0.0")
+	require.NoError(t, err)
+	official, err := version.NewVersion("0.0.0")
 	require.NoError(t, err)
 
-	err = writeVersionFile(v, tmpDir)
+	err = writeVersionFile(internal, official, tmpDir)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(tmpDir, "version.generated.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(content), `const UnifiVersion = "0.0.0"`)
+	assert.Contains(t, string(content), `const OfficialAPIVersion = "0.0.0"`)
 }
 
 func TestWriteVersionRepoMarkerFile_Permissions(t *testing.T) {
@@ -391,6 +417,78 @@ func TestWriteVersionRepoMarkerFile_Permissions(t *testing.T) {
 	err = writeVersionRepoMarkerFile(v, readOnlyDir)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "permission denied")
+}
+
+func TestWriteOfficialVersionRepoMarkerFile(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	tmpDir := t.TempDir()
+	v, err := version.NewVersion("10.1.78")
+	require.NoError(t, err)
+
+	err = writeOfficialVersionRepoMarkerFile(v, tmpDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version-official"))
+	require.NoError(t, err)
+	a.Equal("10.1.78", string(content))
+}
+
+func TestWriteOfficialVersionRepoMarkerFile_InvalidDir(t *testing.T) {
+	t.Parallel()
+
+	v, err := version.NewVersion("10.1.78")
+	require.NoError(t, err)
+
+	err = writeOfficialVersionRepoMarkerFile(v, "/nonexistent/directory")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such file or directory")
+}
+
+func TestWriteOfficialVersionRepoMarkerFile_Permissions(t *testing.T) {
+	t.Parallel()
+
+	if os.Getuid() == 0 {
+		t.Skip("Skipping test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	err := os.Mkdir(readOnlyDir, 0o555)
+	require.NoError(t, err)
+
+	v, err := version.NewVersion("10.1.78")
+	require.NoError(t, err)
+
+	err = writeOfficialVersionRepoMarkerFile(v, readOnlyDir)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "permission denied")
+}
+
+// TestWriteVersionRepoMarkersIndependent verifies Internal and Official markers
+// are written to separate files and their content is independent — the two API
+// surfaces can legitimately pin different versions.
+func TestWriteVersionRepoMarkersIndependent(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	internal, err := version.NewVersion("9.5.21")
+	require.NoError(t, err)
+	official, err := version.NewVersion("10.1.78")
+	require.NoError(t, err)
+
+	require.NoError(t, writeVersionRepoMarkerFile(internal, tmpDir))
+	require.NoError(t, writeOfficialVersionRepoMarkerFile(official, tmpDir))
+
+	internalContent, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version"))
+	require.NoError(t, err)
+	officialContent, err := os.ReadFile(filepath.Join(tmpDir, ".unifi-version-official"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "9.5.21", string(internalContent))
+	assert.Equal(t, "10.1.78", string(officialContent))
+	assert.NotEqual(t, string(internalContent), string(officialContent))
 }
 
 // recordingVersionProvider records which provider methods resolveOfficialSpecVersion

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -15,8 +15,11 @@ This table maps `go-unifi` library releases to the range of UniFi Network Contro
 > well, but this is **not checked**. If you hit an issue on a specific controller version, please
 > [open an issue](https://github.com/filipowm/go-unifi/issues).
 
-The library is updated daily to track the latest UniFi Controller releases, so the "Latest" value moves forward over time. 
-The controller version a given build targets is recorded in [`.unifi-version`](../.unifi-version).
+The library is updated daily to track the latest UniFi Controller releases, so the "Latest" value moves forward over time.
+Two plain-text version markers are written at the repo root by `go generate`:
+
+- [`.unifi-version`](../.unifi-version) — the Internal (legacy) API controller version
+- [`.unifi-version-official`](../.unifi-version-official) — the Official OpenAPI (`integration/v1`) spec version (requires controller ≥ `10.1.78`)
 
 ## Compatibility Changelog
 


### PR DESCRIPTION
Adds a second plain-text version marker so both API surfaces are recorded independently. Purely additive — `.unifi-version` is unchanged in format and location (hard backward-compat requirement).

Part of epic #117.

## What changed
- **`codegen/version.go`**: new `.unifi-version-official` writer mirroring the internal-marker writer; `writeVersionFile` now also emits `const OfficialAPIVersion` beside `const UnifiVersion` (sourced from the gen-time-resolved official version, not hardcoded).
- **`codegen/main.go`**: writes the official marker to the repo root alongside the internal one; passes the resolved official version into `writeVersionFile`.
- **`README.md`**: second shields.io badge for the Official API version (Internal badge untouched); "Latest version" line now names both.
- **`.github/workflows/generate.yaml`**: surfaces the official version in the generate PR; existing `.unifi-version` read unchanged.
- **`docs/compatibility_matrix.md`**, **`CLAUDE.md`**: prose describes both markers.
- Codegen **unit tests** for the official-marker writer and the dual-const emission.

## Gate
`go build ./...`, full `go test`, `golangci-lint run` — all green.

## Note on the generated file (intentional)
This PR ships **codegen source + tests only**. `unifi/version.generated.go` and `.unifi-version-official` are produced by the daily `generate.yaml` regeneration (full `go generate` needs the controller download), so `OfficialAPIVersion` and the marker file land on `main`/`feat/2.0.0` via CI, not by hand. No `*.generated.go` was hand-edited. The new README badge and the `.unifi-version-official` doc link resolve once that regen commits.

## Deferred (non-blocking) review findings
Architect/test-lead review surfaced only minor/nit items, logged for follow-up:
- **DRY**: the two marker writers are near-identical — collapse into one `writeRepoMarker(v, path)` helper.
- `writeVersionFile` now takes two adjacent `*version.Version` params (transposition risk) — consider a `{Internal, Official}` struct or the resolved pair.
- Add godoc on the emitted `UnifiVersion` (Internal/legacy) and `OfficialAPIVersion` (Official OpenAPI) consts to disambiguate.
- `codegen/CLAUDE.md` is now slightly stale (still describes only `.unifi-version` / single const) — beyond the issue's explicit doc list (§5) but worth a follow-up.
- Equal-marker path (internal ≥ 10.1.78 → both versions identical) is untested; only the divergent case is covered.
- Minor test redundancy / table-driven style nits.

> [!NOTE]
> Soft overlap with #135 on `codegen/main.go`. Per plan there's no hard ordering dependency; whichever lands second rebases. This branch will be rebased after #135 merges.