### PR TITLE
fix(device): make DevicePortOverrides.QOSProfile a pointer so omitempty drops empty qos_profile (#149)

### DIFF
--- a/codegen/customizations.yml
+++ b/codegen/customizations.yml
@@ -492,6 +492,8 @@ customizations:
           customUnmarshalType: "booleanishString"
         PortOverrides:
           omitEmpty: false
+        QOSProfile:
+          fieldType: "*DeviceQOSProfile"
     FirewallZone:
       resourcePath: "firewall/zone"
       fields:

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -337,51 +337,51 @@ func (dst *DeviceOutletOverrides) UnmarshalJSON(b []byte) error {
 }
 
 type DevicePortOverrides struct {
-	AggregateMembers             []int            `json:"aggregate_members,omitempty"` // [1-9]|[1-4][0-9]|5[0-6]
-	Autoneg                      bool             `json:"autoneg,omitempty"`
-	Dot1XCtrl                    string           `json:"dot1x_ctrl,omitempty" validate:"omitempty,oneof=auto force_authorized force_unauthorized mac_based multi_host"` // auto|force_authorized|force_unauthorized|mac_based|multi_host
-	Dot1XIDleTimeout             int              `json:"dot1x_idle_timeout,omitempty"`                                                                                  // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
-	EgressRateLimitKbps          int              `json:"egress_rate_limit_kbps,omitempty"`                                                                              // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
-	EgressRateLimitKbpsEnabled   bool             `json:"egress_rate_limit_kbps_enabled,omitempty"`
-	ExcludedNetworkIDs           []string         `json:"excluded_networkconf_ids,omitempty"`
-	FecMode                      string           `json:"fec_mode,omitempty" validate:"omitempty,oneof=rs-fec fc-fec default disabled"` // rs-fec|fc-fec|default|disabled
-	FlowControlEnabled           bool             `json:"flow_control_enabled,omitempty"`
-	Forward                      string           `json:"forward,omitempty" validate:"omitempty,oneof=all native customize disabled"` // all|native|customize|disabled
-	FullDuplex                   bool             `json:"full_duplex,omitempty"`
-	Isolation                    bool             `json:"isolation,omitempty"`
-	LldpmedEnabled               bool             `json:"lldpmed_enabled,omitempty"`
-	LldpmedNotifyEnabled         bool             `json:"lldpmed_notify_enabled,omitempty"`
-	MirrorPortIDX                int              `json:"mirror_port_idx,omitempty"` // [1-9]|[1-4][0-9]|5[0-6]
-	MulticastRouterNetworkIDs    []string         `json:"multicast_router_networkconf_ids,omitempty"`
-	NATiveNetworkID              string           `json:"native_networkconf_id,omitempty"`
-	Name                         string           `json:"name,omitempty" validate:"omitempty,gte=0,lte=128"`                         // .{0,128}
-	OpMode                       string           `json:"op_mode,omitempty" validate:"omitempty,oneof=switch mirror aggregate"`      // switch|mirror|aggregate
-	PoeMode                      string           `json:"poe_mode,omitempty" validate:"omitempty,oneof=auto pasv24 passthrough off"` // auto|pasv24|passthrough|off
-	PortIDX                      int              `json:"port_idx,omitempty"`                                                        // [1-9]|[1-4][0-9]|5[0-6]
-	PortKeepaliveEnabled         bool             `json:"port_keepalive_enabled,omitempty"`
-	PortProfileID                string           `json:"portconf_id,omitempty" validate:"omitempty,w_regex"` // [\d\w]+
-	PortSecurityEnabled          bool             `json:"port_security_enabled,omitempty"`
-	PortSecurityMACAddress       []string         `json:"port_security_mac_address,omitempty" validate:"omitempty,dive,mac"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
-	PriorityQueue1Level          int              `json:"priority_queue1_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
-	PriorityQueue2Level          int              `json:"priority_queue2_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
-	PriorityQueue3Level          int              `json:"priority_queue3_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
-	PriorityQueue4Level          int              `json:"priority_queue4_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
-	QOSProfile                   DeviceQOSProfile `json:"qos_profile,omitempty"`
-	SettingPreference            string           `json:"setting_preference,omitempty" validate:"omitempty,oneof=auto manual"`                                   // auto|manual
-	Speed                        int              `json:"speed,omitempty" validate:"omitempty,oneof=10 100 1000 2500 5000 10000 20000 25000 40000 50000 100000"` // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
-	StormctrlBroadcastastEnabled bool             `json:"stormctrl_bcast_enabled,omitempty"`
-	StormctrlBroadcastastLevel   int              `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlBroadcastastRate    int              `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlMcastEnabled        bool             `json:"stormctrl_mcast_enabled,omitempty"`
-	StormctrlMcastLevel          int              `json:"stormctrl_mcast_level,omitempty"`                                // [0-9]|[1-9][0-9]|100
-	StormctrlMcastRate           int              `json:"stormctrl_mcast_rate,omitempty"`                                 // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StormctrlType                string           `json:"stormctrl_type,omitempty" validate:"omitempty,oneof=level rate"` // level|rate
-	StormctrlUcastEnabled        bool             `json:"stormctrl_ucast_enabled,omitempty"`
-	StormctrlUcastLevel          int              `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
-	StormctrlUcastRate           int              `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
-	StpPortMode                  bool             `json:"stp_port_mode,omitempty"`
-	TaggedVLANMgmt               string           `json:"tagged_vlan_mgmt,omitempty" validate:"omitempty,oneof=auto block_all custom"` // auto|block_all|custom
-	VoiceNetworkID               string           `json:"voice_networkconf_id,omitempty"`
+	AggregateMembers             []int             `json:"aggregate_members,omitempty"` // [1-9]|[1-4][0-9]|5[0-6]
+	Autoneg                      bool              `json:"autoneg,omitempty"`
+	Dot1XCtrl                    string            `json:"dot1x_ctrl,omitempty" validate:"omitempty,oneof=auto force_authorized force_unauthorized mac_based multi_host"` // auto|force_authorized|force_unauthorized|mac_based|multi_host
+	Dot1XIDleTimeout             int               `json:"dot1x_idle_timeout,omitempty"`                                                                                  // [0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]
+	EgressRateLimitKbps          int               `json:"egress_rate_limit_kbps,omitempty"`                                                                              // 6[4-9]|[7-9][0-9]|[1-9][0-9]{2,6}
+	EgressRateLimitKbpsEnabled   bool              `json:"egress_rate_limit_kbps_enabled,omitempty"`
+	ExcludedNetworkIDs           []string          `json:"excluded_networkconf_ids,omitempty"`
+	FecMode                      string            `json:"fec_mode,omitempty" validate:"omitempty,oneof=rs-fec fc-fec default disabled"` // rs-fec|fc-fec|default|disabled
+	FlowControlEnabled           bool              `json:"flow_control_enabled,omitempty"`
+	Forward                      string            `json:"forward,omitempty" validate:"omitempty,oneof=all native customize disabled"` // all|native|customize|disabled
+	FullDuplex                   bool              `json:"full_duplex,omitempty"`
+	Isolation                    bool              `json:"isolation,omitempty"`
+	LldpmedEnabled               bool              `json:"lldpmed_enabled,omitempty"`
+	LldpmedNotifyEnabled         bool              `json:"lldpmed_notify_enabled,omitempty"`
+	MirrorPortIDX                int               `json:"mirror_port_idx,omitempty"` // [1-9]|[1-4][0-9]|5[0-6]
+	MulticastRouterNetworkIDs    []string          `json:"multicast_router_networkconf_ids,omitempty"`
+	NATiveNetworkID              string            `json:"native_networkconf_id,omitempty"`
+	Name                         string            `json:"name,omitempty" validate:"omitempty,gte=0,lte=128"`                         // .{0,128}
+	OpMode                       string            `json:"op_mode,omitempty" validate:"omitempty,oneof=switch mirror aggregate"`      // switch|mirror|aggregate
+	PoeMode                      string            `json:"poe_mode,omitempty" validate:"omitempty,oneof=auto pasv24 passthrough off"` // auto|pasv24|passthrough|off
+	PortIDX                      int               `json:"port_idx,omitempty"`                                                        // [1-9]|[1-4][0-9]|5[0-6]
+	PortKeepaliveEnabled         bool              `json:"port_keepalive_enabled,omitempty"`
+	PortProfileID                string            `json:"portconf_id,omitempty" validate:"omitempty,w_regex"` // [\d\w]+
+	PortSecurityEnabled          bool              `json:"port_security_enabled,omitempty"`
+	PortSecurityMACAddress       []string          `json:"port_security_mac_address,omitempty" validate:"omitempty,dive,mac"` // ^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$
+	PriorityQueue1Level          int               `json:"priority_queue1_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
+	PriorityQueue2Level          int               `json:"priority_queue2_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
+	PriorityQueue3Level          int               `json:"priority_queue3_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
+	PriorityQueue4Level          int               `json:"priority_queue4_level,omitempty"`                                   // [0-9]|[1-9][0-9]|100
+	QOSProfile                   *DeviceQOSProfile `json:"qos_profile,omitempty"`
+	SettingPreference            string            `json:"setting_preference,omitempty" validate:"omitempty,oneof=auto manual"`                                   // auto|manual
+	Speed                        int               `json:"speed,omitempty" validate:"omitempty,oneof=10 100 1000 2500 5000 10000 20000 25000 40000 50000 100000"` // 10|100|1000|2500|5000|10000|20000|25000|40000|50000|100000
+	StormctrlBroadcastastEnabled bool              `json:"stormctrl_bcast_enabled,omitempty"`
+	StormctrlBroadcastastLevel   int               `json:"stormctrl_bcast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlBroadcastastRate    int               `json:"stormctrl_bcast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlMcastEnabled        bool              `json:"stormctrl_mcast_enabled,omitempty"`
+	StormctrlMcastLevel          int               `json:"stormctrl_mcast_level,omitempty"`                                // [0-9]|[1-9][0-9]|100
+	StormctrlMcastRate           int               `json:"stormctrl_mcast_rate,omitempty"`                                 // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StormctrlType                string            `json:"stormctrl_type,omitempty" validate:"omitempty,oneof=level rate"` // level|rate
+	StormctrlUcastEnabled        bool              `json:"stormctrl_ucast_enabled,omitempty"`
+	StormctrlUcastLevel          int               `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
+	StormctrlUcastRate           int               `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
+	StpPortMode                  bool              `json:"stp_port_mode,omitempty"`
+	TaggedVLANMgmt               string            `json:"tagged_vlan_mgmt,omitempty" validate:"omitempty,oneof=auto block_all custom"` // auto|block_all|custom
+	VoiceNetworkID               string            `json:"voice_networkconf_id,omitempty"`
 }
 
 func (dst *DevicePortOverrides) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
## What

`DevicePortOverrides.QOSProfile` was a **value** type `DeviceQOSProfile` with `json:"qos_profile,omitempty"`. Go's `encoding/json` never treats a struct value as empty, so `omitempty` was a no-op — every Device serialisation emitted `"qos_profile":{}`, which UDM SE controllers reject with `api.err.NotSupportQosConfig`, breaking Device port-override management.

Fix at the codegen source: value → pointer (`*DeviceQOSProfile`) so a nil pointer is actually dropped.

## How

- `codegen/customizations.yml`: one field override under `Device.fields` — `QOSProfile: { fieldType: "*DeviceQOSProfile" }`.
- Regenerated via `go generate unifi/codegen.go` (offline, pinned 9.5.21 snapshot).
- Golden diff is limited to `unifi/device.generated.go`: `QOSProfile DeviceQOSProfile` → `*DeviceQOSProfile`. The rest of the churn is gofmt column realignment from the longer type name. `DeviceQOSProfile` struct + its `UnmarshalJSON` untouched.
- **Not** a cherry-pick of #108 (which hand-edited the `DO NOT EDIT` generated file).

## Notes

- **Breaking**: `*DeviceQOSProfile` changes the public field type. Zero non-generated consumers exist in this repo (the only other `QOSProfile` hit is the unrelated `PortProfile.QOSProfile`). External consumers assigning by value must now take the address.
- Lands on `main` first by request; will be forward-merged into `feat/2.0.0`. The migration note + `breaking_changes.md` provenance entry are owned by the separate 2.0.0 docs issue — this PR touches no docs.
- Gate: `go build`, full `go test`, `golangci-lint run` all green.

Refs #149