### PR TITLE
chore(module): bump module path to /v2 for the breaking 2.0.0 release (#147)

### DIFF
--- a/codegen/download_root_test.go
+++ b/codegen/download_root_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/filipowm/go-unifi/codegen/internal"
+	"github.com/filipowm/go-unifi/v2/codegen/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ulikunitz/xz"

--- a/codegen/internal/client.go.tmpl
+++ b/codegen/internal/client.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"{{ $v }}"
 	{{- end }}
 
-	"github.com/filipowm/go-unifi/unifi/official"
+	"github.com/filipowm/go-unifi/v2/unifi/official"
 )
 
 // InternalClient is the legacy UniFi Network ("Internal") API surface: every

--- a/codegen/internal/clients_test.go
+++ b/codegen/internal/clients_test.go
@@ -187,5 +187,5 @@ func TestGenerateCode(t *testing.T) {
 	a.NotEmpty(code, "GenerateCode() returned empty code")
 	a.Contains(code, "TestFunc")
 	// Ensure the hardcoded official-API import survives template relocation.
-	a.Contains(code, "github.com/filipowm/go-unifi/unifi/official")
+	a.Contains(code, "github.com/filipowm/go-unifi/v2/unifi/official")
 }

--- a/codegen/internal/customize.go
+++ b/codegen/internal/customize.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"gopkg.in/yaml.v3"
 )
 

--- a/codegen/internal/download.go
+++ b/codegen/internal/download.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/iancoleman/strcase"
 	"github.com/ulikunitz/xz"
 	"github.com/xor-gate/ar"

--- a/codegen/internal/download_test.go
+++ b/codegen/internal/download_test.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ulikunitz/xz"

--- a/codegen/internal/generate.go
+++ b/codegen/internal/generate.go
@@ -7,7 +7,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 )
 
 // Generate runs the Internal-API code generation pass: builds resources from

--- a/codegen/internal/generator.go
+++ b/codegen/internal/generator.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/iancoleman/strcase"
 )
 

--- a/codegen/internal/log.go
+++ b/codegen/internal/log.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/sirupsen/logrus"
 )
 

--- a/codegen/internal/resources.go
+++ b/codegen/internal/resources.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/iancoleman/strcase"
 )
 

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/filipowm/go-unifi/codegen/internal"
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/internal"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/sirupsen/logrus"
 )
 

--- a/codegen/main_test.go
+++ b/codegen/main_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/filipowm/go-unifi/codegen/internal"
+	"github.com/filipowm/go-unifi/v2/codegen/internal"
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/codegen/utils.go
+++ b/codegen/utils.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/filipowm/go-unifi/codegen/shared"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 )
 
 // ensurePath delegates to shared.EnsurePath. The local wrapper keeps

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/filipowm/go-unifi
+module github.com/filipowm/go-unifi/v2
 
 go 1.26.0
 

--- a/unifi/account_test.go
+++ b/unifi/account_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 	"github.com/tj/assert"
 )
 

--- a/unifi/client.generated.go
+++ b/unifi/client.generated.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/filipowm/go-unifi/unifi/official"
+	"github.com/filipowm/go-unifi/v2/unifi/official"
 )
 
 // InternalClient is the legacy UniFi Network ("Internal") API surface: every

--- a/unifi/client.go
+++ b/unifi/client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/filipowm/go-unifi/unifi/official"
+	"github.com/filipowm/go-unifi/v2/unifi/official"
 )
 
 // ValidationMode represents the mode for request validation.

--- a/unifi/client_mock.generated.go
+++ b/unifi/client_mock.generated.go
@@ -5,7 +5,7 @@ package unifi
 
 import (
 	"context"
-	"github.com/filipowm/go-unifi/unifi/official"
+	"github.com/filipowm/go-unifi/v2/unifi/official"
 	"io"
 	"sync"
 )

--- a/unifi/mock_test.go
+++ b/unifi/mock_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/unifi/network_test.go
+++ b/unifi/network_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 )
 
 func TestNetworkUnmarshalJSON(t *testing.T) {

--- a/unifi/official_surface.go
+++ b/unifi/official_surface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/filipowm/go-unifi/unifi/official"
+	"github.com/filipowm/go-unifi/v2/unifi/official"
 	goversion "github.com/hashicorp/go-version"
 )
 


### PR DESCRIPTION
Bumps the Go module path to `github.com/filipowm/go-unifi/v2` — the foundational breaking change for 2.0.0. Go semantic-import-versioning requires a `/vN` path for major ≥ 2 (no `+incompatible` once a `go.mod` is present), so tagging `v2.0.0` against the unsuffixed module line would produce an **uninstallable release**. This must land before the `v2.0.0` tag and before any other consumer-facing change.

## What changed (code only)
- `go.mod` module line → `.../v2`; `go 1.26.0` unchanged.
- Hand-written `.go` imports (root + `codegen/`) rewritten to `/v2/...`.
- Codegen template `client.go.tmpl` + assertion `clients_test.go` → `/v2/unifi/official`.
- Regenerated (not hand-edited): `unifi/client.generated.go` and `unifi/client_mock.generated.go` (mock via installed `moq` binary).

## Deliberately untouched
- Nested separate module `codegen/official` (`go.mod` + `modulePath` const) — internal build-time tooling, never published/consumed, correctly stays unversioned per SIV.
- `unifi/official/*.generated.go` `// Code generated by …/codegen/official` banners reference the *generator*, not an import.

## Out of scope (delegated to #148)
All README/docs path & badge rewrites — the import/install/pkg.go.dev `/v2` sweep is judgment-laden (repo URLs must NOT get `/v2`) and is owned by the docs issue. **This PR is code-only.** The breaking-change writeup also lands with #148.

## Gate
`go build ./...`, full `go test`, `golangci-lint run` (0 issues) — all green under the `/v2` path. Post-push `go install .../v2/...@<pseudo>` clean-cache resolution is verified at release/tag time.

Refs #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)