### PR TITLE
chore(ci): re-enable daily codegen cron at 03:37 UTC (#151)

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,8 +1,11 @@
 ---
 name: "Generate Unifi structures"
 on:
-#  schedule:
-#    - cron: "0 0 * * *"
+  # Off-peak minute (not :00) to avoid GitHub's top-of-hour scheduler congestion.
+  # Internal generation is capped at 9.5.21 (#129), so that half is an expected
+  # no-op; the live-moving part is the Official OpenAPI snapshot.
+  schedule:
+    - cron: "37 3 * * *"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Re-enables the `schedule:` trigger in `.github/workflows/generate.yaml`, commented out during the #117 migration, so the advertised daily automated regen runs again.

## What changed
- Uncommented `schedule:` with `cron: "37 3 * * *"` — daily at **03:37 UTC**.
  - GitHub cron is UTC-only and can't randomize; an off-peak minute (not `:00`) avoids GitHub's top-of-hour scheduler congestion where jobs get delayed/dropped.
- `workflow_dispatch` retained for manual runs.
- Added a short comment noting the Internal cap (#129) means that half is an expected no-op; the Official OpenAPI snapshot is the live-moving part.

## Out of scope (deliberately)
- No prose edits to `README.md` / `docs/compatibility_matrix.md` — owned by the docs issue #148 to avoid a merge collision.
- The standing `# TODO: auto-merge the PR` is left as-is.

## Notes on acceptance
- Workflow-only change: `go build` / `golangci-lint` unaffected.
- **Scheduled triggers only fire from the default branch (`main`).** Uncommenting on `feat/2.0.0` has no effect until merged to `main`; the cron's first real run can only be observed post-merge-to-main. Pre-merge validation is via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)