### PR TITLE
docs(2.0.0): front-door docs — compile-fix examples, 1.x→2.0 migration guide, raw-call escape hatch (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@
 ![Supported Internal API Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version&search=(.*)%3F&logo=ubiquiti&label=Supported%20Internal%20API%20Version&color=yellow)
 ![Supported Official API Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffilipowm%2Fgo-unifi%2Frefs%2Fheads%2Fmain%2F.unifi-version-official&search=(.*)%3F&logo=ubiquiti&label=Supported%20Official%20API%20Version&color=blue)
 [![Docs](https://img.shields.io/badge/docs-reference-blue)](https://github.com/filipowm/go-unifi/blob/main/docs/readme.md)
-[![GoDoc](https://godoc.org/github.com/filipowm/go-unifi?status.svg)](https://godoc.org/github.com/filipowm/go-unifi)
+[![Go Reference](https://pkg.go.dev/badge/github.com/filipowm/go-unifi/v2/unifi.svg)](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi)
 ![GitHub branch check runs](https://img.shields.io/github/check-runs/filipowm/go-unifi/main)
 ![GitHub License](https://img.shields.io/github/license/filipowm/go-unifi)
 
 This SDK provides a Go client for the UniFi Network Controller API. It is used primarily in the [Terraform provider for UniFi](https://github.com/filipowm/terraform-provider-unifi),
 but can be used independently for any Go project requiring UniFi Network Controller API integration.
 
-Check out the detailed [documentation](docs/readme.md) for more information.
+Check out the detailed [documentation](docs/readme.md) for more information, including the
+[1.x → 2.0 migration guide](docs/2.0.0/migration_guide.md) and the
+[breaking-changes log](docs/2.0.0/breaking_changes.md).
 
 ## Features
 
 - Great UniFi Network Controller API coverage through automated code generation and manually added code for undocumented endpoints
-- Easy to use client with support for API Key and username/password authentication
+- Easy to use client with support for API Key authentication (username/password removed in 2.0.0)
 - Generated data models from UniFi Controller API specifications
 - Daily automated updates to track the latest UniFi Controller versions
 - Support for multiple UniFi Controller versions
@@ -24,7 +26,13 @@ Check out the detailed [documentation](docs/readme.md) for more information.
 
 ## Supported UniFi Controller Versions
 
-Any version after 5.12.35 is supported as of now. **Latest Internal API version: 9.5.21; Latest Official API version: 10.1.78**.
+API-key authentication (the only supported auth in 2.0.0) requires a new-style UniFi OS controller,
+version **9.0.108** or newer. Old-style (classic) controllers are unsupported and construction fails
+immediately with `ErrOldStyleUnsupported`.
+
+The Internal API is tested against controller **9.5.21** (`.unifi-version`). The Official OpenAPI
+surface (`c.Official()`) requires controller **10.1.78** or newer (`.unifi-version-official`).
+
 The SDK is updated daily to track the latest UniFi Controller versions.
 If you encounter any issues with the latest UniFi Controller version, please open an issue.
 
@@ -56,13 +64,19 @@ and the UniFi Controller JAR is obfuscated, making it challenging to directly us
 
 ## Migrating from `paultyng/go-unifi`
 
-If you already use `paultyng/go-unifi`, you can easily migrate to this SDK, because it is a fork and the SDK is fully compatible with the original one.
+If you already use `paultyng/go-unifi`, you can migrate to this SDK — it is a fork and the core client
+methods remain the same.
 Check out the [migration guide](docs/migrating_from_upstream.md) for information on how to migrate from the upstream `paultyng/go-unifi` SDK.
+
+## Upgrading from go-unifi 1.x
+
+See the [1.x → 2.0 migration guide](docs/2.0.0/migration_guide.md) for a step-by-step walkthrough of every
+breaking change. A quick reference of all 10 breaks is in
+[breaking_changes.md](docs/2.0.0/breaking_changes.md).
 
 ## Usage
 
-Unifi client support both username/password and API Key authentication. It is recommended to use API Key authentication for better security,
-as well as dedicated user restricted to local access only.
+The UniFi client requires API Key authentication (available from UniFi Controller 9.0.108+).
 
 ### Obtaining an API Key
 
@@ -73,24 +87,14 @@ as well as dedicated user restricted to local access only.
 5. Add a name for your API Key.
 6. Copy the key and store it securely, as it will only be displayed once.
 7. Click Done to ensure the key is hashed and securely stored.
-8. Use the API Key 🎉
+8. Use the API Key
 
 ### Client Initialization
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-BaseURL: "https://unifi.localdomain",
-APIKey: "your-api-key",
-})
-```
-
-Instead of API Key, you can also use username/password for authentication:
-
-```go
-c, err := unifi.NewClient(&unifi.ClientConfig{
-BaseURL: "https://unifi.localdomain",
-Username: "your-username",
-Password: "your-password",
+    URL:    "https://unifi.localdomain",
+    APIKey: "your-api-key",
 })
 ```
 
@@ -102,12 +106,13 @@ controller's CA instead.
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-...
-SkipVerifySSL: true, // disable TLS verification (self-signed cert)
+    URL:           "https://unifi.localdomain",
+    APIKey:        "your-api-key",
+    SkipVerifySSL: true, // disable TLS verification (self-signed cert)
 })
 ```
 
-List of available client configuration options is available [here](https://pkg.go.dev/github.com/filipowm/go-unifi/unifi#ClientConfig).
+List of available client configuration options is available [here](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientConfig).
 
 ### Internal vs Official API
 
@@ -144,6 +149,9 @@ all, err := official.Collect(c.Official().Networks().ListAll(ctx, id, "")) // ex
 pol, err := c.Official().Firewall().CreatePolicy(ctx, id, body) // fluent, per-group accessor
 ```
 
+> **Resource groups:** `Hotspot()` exposes Vouchers; `Firewall()` exposes `PatchPolicy` and other
+> firewall resources. The Official surface has no top-level `Vouchers()` accessor — use `c.Official().Hotspot()`.
+
 In **2.0.0 the Internal surface stays the canonical default**, so existing code is untouched — calling a
 resource method on the client is identical to calling it on `c.Internal()`. **3.0.0 is expected to flip the
 default to the Official client.** The Official client is gated: operations return
@@ -153,17 +161,23 @@ either with `errors.Is`. Site identifiers differ between the surfaces — the In
 **name** while the Official API uses a **UUID** — so `Official().Sites().ResolveID` maps the familiar name
 to the UUID for you.
 
+### Low-level API calls
+
+For endpoints not covered by a generated method, the client exposes `Do`, `Get`, `Post`, `Put`, `Patch`,
+and `Delete`. See [Advanced Topics](docs/advanced_topics.md) for the path-resolution rules and examples.
+
 ### Customizing HTTP Client
 
 You can customize underlying HTTP client by using `HttpTransportCustomizer` interface:
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-...
-HttpTransportCustomizer: func (transport *http.Transport) (*http.Transport, error) {
-transport.MaxIdleConns = 10
-return transport, nil
-},
+    URL:    "https://unifi.localdomain",
+    APIKey: "your-api-key",
+    HttpTransportCustomizer: func (transport *http.Transport) (*http.Transport, error) {
+        transport.MaxIdleConns = 10
+        return transport, nil
+    },
 })
 ```
 
@@ -172,25 +186,26 @@ return transport, nil
 You can use interceptors to modify requests and responses. This gives you more control over the client behavior
 and flexibility to add custom logic.
 
-To use interceptor logic, you need to create a struct implementing [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/unifi#ClientInterceptor) interface.
+To use interceptor logic, you need to create a struct implementing [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientInterceptor) interface.
 For example, you can use interceptors to log requests and responses:
 
 ```go
 type LoggingInterceptor struct{}
 
 func (l *LoggingInterceptor) InterceptRequest(req *http.Request) error {
-log.Printf("Request: %s %s", req.Method, req.URL)
-return nil
+    log.Printf("Request: %s %s", req.Method, req.URL)
+    return nil
 }
 
 func (l *LoggingInterceptor) InterceptResponse(resp *http.Response) error {
-log.Printf("Response status: %d", resp.StatusCode)
-return nil
+    log.Printf("Response status: %d", resp.StatusCode)
+    return nil
 }
 
 c, err := unifi.NewClient(&unifi.ClientConfig{
-...
-Interceptors: []unifi.ClientInterceptor{&LoggingInterceptor{}},
+    URL:          "https://unifi.localdomain",
+    APIKey:       "your-api-key",
+    Interceptors: []unifi.ClientInterceptor{&LoggingInterceptor{}},
 })
 ```
 
@@ -210,8 +225,9 @@ To change the validation mode, you can use the `ValidationMode` field in the cli
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-...
-ValidationMode: unifi.HardValidation,
+    URL:            "https://unifi.localdomain",
+    APIKey:         "your-api-key",
+    ValidationMode: unifi.HardValidation,
 })
 ```
 
@@ -219,17 +235,17 @@ If you use hard validation, you can get access to `unifi.ValidationError` struct
 
 ```go
 n := &unifi.Network{
-Name:     "my-network",
-Purpose:  "invalid-purpose",
-IPSubnet: "10.0.0.10/24",
+    Name:     "my-network",
+    Purpose:  "invalid-purpose",
+    IPSubnet: "10.0.0.10/24",
 }
 _, err = c.CreateNetwork(ctx, "default", n)
 
 if err != nil {
-validationError := &unifi.ValidationError{}
-errors.As(err, &validationError)
-fmt.Printf("Error: %v\n", validationError)
-fmt.Printf("Root: %v\n", validationError.Root)
+    validationError := &unifi.ValidationError{}
+    errors.As(err, &validationError)
+    fmt.Printf("Error: %v\n", validationError)
+    fmt.Printf("Root: %v\n", validationError.Root)
 }
 ```
 
@@ -248,10 +264,10 @@ Create user assigned to network:
 
 ```go
 user, err := c.CreateUser(ctx, "site-name", &unifi.User{
-Name:      "My Network User",
-MAC:       "00:00:00:00:00:00",
-NetworkID: network[0].ID,
-IP:        "10.0.21.37",
+    Name:      "My Network User",
+    MAC:       "00:00:00:00:00:00",
+    NetworkID: network[0].ID,
+    IP:        "10.0.21.37",
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check out the detailed [documentation](docs/readme.md) for more information, inc
 ## Supported UniFi Controller Versions
 
 API-key authentication (the only supported auth in 2.0.0) requires a new-style UniFi OS controller,
-version **9.0.108** or newer. Old-style (classic) controllers are unsupported and construction fails
+version **9.0.114** or newer. Old-style (classic) controllers are unsupported and construction fails
 immediately with `ErrOldStyleUnsupported`.
 
 The Internal API is tested against controller **9.5.21** (`.unifi-version`). The Official OpenAPI
@@ -76,7 +76,7 @@ breaking change. A quick reference of all 10 breaks is in
 
 ## Usage
 
-The UniFi client requires API Key authentication (available from UniFi Controller 9.0.108+).
+The UniFi client requires API Key authentication (available from UniFi Controller 9.0.114+).
 
 ### Obtaining an API Key
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ c, err := unifi.NewClient(&unifi.ClientConfig{
 })
 ```
 
-List of available client configuration options is available [here](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientConfig).
+See the [full list of client configuration options](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientConfig) on pkg.go.dev.
 
 ### Internal vs Official API
 

--- a/docs/2.0.0/breaking_changes.md
+++ b/docs/2.0.0/breaking_changes.md
@@ -291,26 +291,7 @@ These affect only forks of the generator:
 - `DownloadAndExtract` gained a leading `*http.Client` parameter (TEST-07, Wave 1).
 - `DownloadAndExtract`/`downloadJar` gained a leading `context.Context` parameter (ARCH-15, Wave 2).
 
-### G. `Device.QOSProfile` value → pointer
-
-**Status: DONE** — landed in generated code (device.generated.go).
-
-**Type change (compile break for direct field access).** `Device.QOSProfile` changed from `DeviceQOSProfile`
-(value) to `*DeviceQOSProfile` (pointer). Code that reads the field without a nil check will panic at
-runtime if the field is absent from the API response (nil pointer).
-
-```go
-// before
-mode := device.QOSProfile.QOSProfileMode // direct access on value type
-// after
-if device.QOSProfile != nil {
-    mode := device.QOSProfile.QOSProfileMode // pointer; check nil first
-}
-```
-
-**Provenance:** device.generated.go; delegated from epic #117, issue #148.
-
-### H. `NewBareClient` replaced by `NewClient` + `SkipSystemInfo`
+### G. `NewBareClient` replaced by `NewClient` + `SkipSystemInfo`
 
 **Status: DONE** — landed; `NewBareClient` removed.
 
@@ -326,7 +307,7 @@ c, err := unifi.NewClient(&unifi.ClientConfig{URL: "...", APIKey: "...", SkipSys
 
 **Provenance:** unifi/client.go; delegated from epic #117, issue #148.
 
-### I. New `Patch` method on `Client`
+### H. New `Patch` method on `Client`
 
 **Status: DONE** — landed in unifi/requests.go.
 

--- a/docs/2.0.0/breaking_changes.md
+++ b/docs/2.0.0/breaking_changes.md
@@ -2,31 +2,32 @@
 
 This document is the authoritative changelog of every public-API behavior or signature change introduced
 during the 2.0.0 migration (epic [#117](https://github.com/filipowm/go-unifi/issues/117)). It is keyed to
-the 13 impact-ordered breaking changes enumerated in the epic, each carrying a verified **DONE/PENDING**
+10 breaking changes plus an additive Official surface. Each entry carries a verified **DONE/PENDING**
 status, a migration note, and a provenance link.
 
+See the [1.x → 2.0 migration guide](migration_guide.md) for a task-oriented, junior-to-senior walkthrough
+with rationale and grep hints for each change.
+
 > Status key: **DONE** = change is in the `feat/2.0.0` tree and verified against the actual code.
-> **PENDING** = planned; not yet landed.
+> **PENDING** = planned; not yet landed (see "Planned for 3.0.0" section below).
 
 ---
 
-## Breaking changes — 13-row index (epic #117)
+## Breaking changes — 10 landed + additive Official surface
 
 | # | Change | Impact | Status |
 |---|--------|--------|--------|
 | 1 | [API-key authentication only](#1-api-key-authentication-only) | High | **DONE** |
 | 2 | [TLS verify-by-default](#2-tls-verify-by-default) | High | **DONE** |
 | 3 | [Go version bump to 1.26](#3-go-version-bump-to-126) | Medium | **DONE** |
-| 4 | [OpenAPI-shaped structs](#4-openapi-shaped-structs) | Medium | **PENDING** |
-| 5 | [Occasional field renames](#5-occasional-field-renames) | Medium | **PENDING** |
-| 6 | [New `integration/v1` `APIStyle`](#6-new-integrationv1-apistyle) | Medium | **PENDING** |
-| 7 | [`Client` gains `SetSetting`](#7-client-gains-setsetting) | Medium | **DONE** |
-| 8 | [`Client` gains `*Context` variants](#8-client-gains-context-variants) | Medium | **DONE** |
-| 9 | [v1 `Create`/`Update` no longer return `ErrNotFound`](#9-v1-createupdate-no-longer-return-errnotfound) | Medium | **DONE** |
-| 10 | [`meta.rc=="error"` on HTTP 200 → `*ServerError`](#10-metarcerror-on-http-200--servererror) | Medium | **DONE** |
-| 11 | [Map 404 → `ErrNotFound`](#11-map-404--errnotfound) | Low | **DONE** |
-| 12 | [`UseLocking` is a no-op](#12-uselocking-is-a-no-op) | Low | **DONE** |
-| 13 | [Remove CSRF handling](#13-remove-csrf-handling) | Low | **DONE** |
+| 4 | [`Client` gains `SetSetting`](#4-client-gains-setsetting) | Medium | **DONE** |
+| 5 | [`Client` gains `*Context` variants](#5-client-gains-context-variants) | Medium | **DONE** |
+| 6 | [v1 `Create`/`Update` no longer return `ErrNotFound`](#6-v1-createupdate-no-longer-return-errnotfound) | Medium | **DONE** |
+| 7 | [`meta.rc=="error"` on HTTP 200 → `*ServerError`](#7-metarcerror-on-http-200--servererror) | Medium | **DONE** |
+| 8 | [Map 404 → `ErrNotFound`](#8-map-404--errnotfound) | Low | **DONE** |
+| 9 | [`UseLocking` is a no-op](#9-uselocking-is-a-no-op) | Low | **DONE** |
+| 10 | [Remove CSRF handling](#10-remove-csrf-handling) | Low | **DONE** |
+| — | [Official API surface (additive)](#official-api-surface-additive) | Additive | **DONE** |
 
 ---
 
@@ -90,56 +91,7 @@ upgrade their toolchain.
 
 ---
 
-### 4. OpenAPI-shaped structs
-
-**Status: PENDING** — no resources migrated yet; landing per-resource as part of the OpenAPI generator wave.
-
-**Type change (compile break for each migrated resource).** Resources generated from the official OpenAPI
-spec (`integration.json`) may adopt different field names, types, or nesting than the legacy reverse-engineered
-shapes. Each resource is migrated individually; the breaking surface is bounded to that resource's struct.
-
-Migration: compile against the new module version; fix any field references reported by the compiler.
-
-**Provenance:** epic #117, OpenAPI-generator wave (issues TBD).
-
----
-
-### 5. Occasional field renames
-
-**Status: PENDING** — no field renames yet; land alongside each OpenAPI-driven resource migration.
-
-**Signature change (compile break per renamed field).** Where the official spec uses a different field name
-from the legacy one, the generated struct adopts the spec name. Each rename is documented in this file when
-it lands.
-
-Migration: compile-error-driven; rename at each call site.
-
-**Provenance:** epic #117, per-resource OpenAPI migration.
-
----
-
-### 6. New `integration/v1` `APIStyle`
-
-**Status: PENDING** — routing generated resources through the official `integration/v1` API is part of
-the OpenAPI generator wave (same milestone as rows 4/5); not yet landed.
-
-**Interface change (compile break for custom `Client` implementations).** A new `APIStyle` constant will
-route code-generated resources through the UniFi official `integration/v1` API path instead of the legacy
-`/api/s/{site}/...` endpoints. The generated CRUD methods and their structs will adopt OpenAPI-derived
-shapes (see rows 4/5).
-
-The `integration/v1` path is a capability layered on the new-style API — it is not a fourth independent
-style alongside `V1`, `V2`, and `new-style`; see `unifi/api_paths.go` for the documented constraint.
-
-Note: the `Official()` accessor and the `integration/v1` info/sites vertical that **did** land in PR #119
-are documented in entries [D](#d-client-interface-split-into-internalclient--internalofficial-accessors-119)
-and [E](#e-official-api-unavailable-on-classicold-style-controllers-119) of the provenance index below.
-
-**Provenance:** epic #117, OpenAPI generator wave (issues TBD, same milestone as rows 4/5).
-
----
-
-### 7. `Client` gains `SetSetting`
+### 4. `Client` gains `SetSetting`
 
 **Status: DONE** — landed in Wave 1 (ARCH-08).
 
@@ -157,7 +109,7 @@ type that implements `unifi.Client` must add this method; the moq `ClientMock` i
 
 ---
 
-### 8. `Client` gains `*Context` variants
+### 5. `Client` gains `*Context` variants
 
 **Status: DONE** — landed in Wave 2 (TEST-15); `Login`/`Logout` ctx variants superseded by #125.
 
@@ -177,7 +129,7 @@ The no-ctx `Version`/`GetSystemInformation` remain source-compatible. Any third-
 
 ---
 
-### 9. v1 `Create`/`Update` no longer return `ErrNotFound`
+### 6. v1 `Create`/`Update` no longer return `ErrNotFound`
 
 **Status: DONE** — landed in Wave 2 (ARCH-13).
 
@@ -198,7 +150,7 @@ branch was always incorrect. Treat any non-nil error from `Create<X>`/`Update<X>
 
 ---
 
-### 10. `meta.rc=="error"` on HTTP 200 → `*ServerError`
+### 7. `meta.rc=="error"` on HTTP 200 → `*ServerError`
 
 **Status: DONE** — landed in Wave 2 (ARCH-10).
 
@@ -220,7 +172,7 @@ It is **not** `ErrNotFound` (`errors.Is(err, ErrNotFound) == false`), so genuine
 
 ---
 
-### 11. Map 404 → `ErrNotFound`
+### 8. Map 404 → `ErrNotFound`
 
 **Status: DONE** — landed in Wave 1 (ARCH-05).
 
@@ -234,7 +186,7 @@ sentinel now sees them as equal.
 
 ---
 
-### 12. `UseLocking` is a no-op
+### 9. `UseLocking` is a no-op
 
 **Status: DONE** — landed in Wave 1 (ARCH-04).
 
@@ -247,7 +199,7 @@ config.
 
 ---
 
-### 13. Remove CSRF handling
+### 10. Remove CSRF handling
 
 **Status: DONE** — landed in issue #125 (API-key-only auth).
 
@@ -261,14 +213,31 @@ authentication.
 
 ---
 
+### Official API surface (additive)
+
+**Status: DONE** — landed in PR #119.
+
+The `Client` interface gains `Internal()` and `Official()` accessors. `Internal()` returns the full
+`InternalClient` (all resource CRUD, identical to calling methods directly on the client). `Official()`
+returns the fluent Official OpenAPI client (`integration/v1`), gated behind `ErrOfficialAPIUnavailable`
+on unsupported controllers.
+
+This is additive in 2.0.0 — existing code using resource methods directly on the client is unaffected.
+The default is expected to flip to `Official()` in 3.0.0.
+
+See entries [D](#d-client-interface-split-into-internalclient--internalofficial-accessors-119) and
+[E](#e-official-api-unavailable-on-classicold-style-controllers-119) in the provenance index for details.
+
+---
+
 ## Additional changes — provenance index
 
-Changes already documented in earlier waves that complement the 13-row table. Nothing here is new;
+Changes already documented in earlier waves that complement the 10-row table. Nothing here is new;
 entries are relocated from the prior wave-by-wave structure for traceability.
 
 ### A. `CSRFInterceptor.CSRFToken`: exported field → accessor method (ARCH-04, Wave 1) — superseded by #125
 
-**Superseded by row [#13](#13-remove-csrf-handling).** `CSRFInterceptor` is now entirely removed. This Wave 1
+**Superseded by row [#10](#10-remove-csrf-handling).** `CSRFInterceptor` is now entirely removed. This Wave 1
 intermediate step (field → accessor) is moot; the type is gone. Any code referencing `CSRFInterceptor` in
 any form fails to compile.
 
@@ -299,12 +268,9 @@ interface, so consumers using the `Client` interface are unaffected.
 
 ### D. `Client` interface split into `InternalClient` + `Internal()`/`Official()` accessors (#119)
 
-See [#6 — New `integration/v1` `APIStyle`](#6-new-integrationv1-apistyle) above for the full entry. The
-`InternalClient` embedded interface and the `Internal()`/`Official()` accessors are the structural
-implementation of that row.
-
-This is the **2.0.0-canonical-Internal** step: in 2.0.0 the embedded Internal surface stays the default, so
-existing code is untouched; 3.0.0 is expected to flip the default to the Official client (the **3.0.0-flip**).
+The `InternalClient` embedded interface and the `Internal()`/`Official()` accessors implement the
+2.0.0-canonical-Internal step: in 2.0.0 the embedded Internal surface stays the default, so existing
+code is untouched; 3.0.0 is expected to flip the default to the Official client (the **3.0.0-flip**).
 
 ### E. Official API unavailable on classic/old-style controllers (#119)
 
@@ -324,3 +290,102 @@ These affect only forks of the generator:
 
 - `DownloadAndExtract` gained a leading `*http.Client` parameter (TEST-07, Wave 1).
 - `DownloadAndExtract`/`downloadJar` gained a leading `context.Context` parameter (ARCH-15, Wave 2).
+
+### G. `Device.QOSProfile` value → pointer
+
+**Status: DONE** — landed in generated code (device.generated.go).
+
+**Type change (compile break for direct field access).** `Device.QOSProfile` changed from `DeviceQOSProfile`
+(value) to `*DeviceQOSProfile` (pointer). Code that reads the field without a nil check will panic at
+runtime if the field is absent from the API response (nil pointer).
+
+```go
+// before
+mode := device.QOSProfile.QOSProfileMode // direct access on value type
+// after
+if device.QOSProfile != nil {
+    mode := device.QOSProfile.QOSProfileMode // pointer; check nil first
+}
+```
+
+**Provenance:** device.generated.go; delegated from epic #117, issue #148.
+
+### H. `NewBareClient` replaced by `NewClient` + `SkipSystemInfo`
+
+**Status: DONE** — landed; `NewBareClient` removed.
+
+**Signature change (compile break).** The `NewBareClient` constructor is removed. Use `NewClient` with
+`SkipSystemInfo: true` to achieve the same behaviour (skip the eager `GetSystemInformation()` call).
+
+```go
+// before
+c, err := unifi.NewBareClient(&unifi.ClientConfig{BaseURL: "...", APIKey: "..."})
+// after
+c, err := unifi.NewClient(&unifi.ClientConfig{URL: "...", APIKey: "...", SkipSystemInfo: true})
+```
+
+**Provenance:** unifi/client.go; delegated from epic #117, issue #148.
+
+### I. New `Patch` method on `Client`
+
+**Status: DONE** — landed in unifi/requests.go.
+
+**Additive change (no compile break).** The `Client` interface and concrete `*client` expose a `Patch`
+method for HTTP PATCH requests, alongside the existing `Do`/`Get`/`Post`/`Put`/`Delete`.
+
+```go
+// new in 2.0.0
+err := c.Patch(ctx, "s/default/rest/networkconf/<id>", patchBody, &resp)
+```
+
+**Provenance:** unifi/requests.go; delegated from epic #117, issue #148.
+
+---
+
+## Planned for 3.0.0
+
+The following changes from the original epic #117 13-row index are **not** landing in 2.0.0. They are
+deferred to the next major version.
+
+### 4. OpenAPI-shaped structs (deferred to 3.0.0)
+
+**Status: PENDING** — no resources migrated yet; landing per-resource as part of the OpenAPI generator wave.
+
+**Type change (compile break for each migrated resource).** Resources generated from the official OpenAPI
+spec (`integration.json`) may adopt different field names, types, or nesting than the legacy reverse-engineered
+shapes. Each resource is migrated individually; the breaking surface is bounded to that resource's struct.
+
+Migration: compile against the new module version; fix any field references reported by the compiler.
+
+**Provenance:** epic #117, OpenAPI-generator wave (issues TBD).
+
+### 5. Occasional field renames (deferred to 3.0.0)
+
+**Status: PENDING** — no field renames yet; land alongside each OpenAPI-driven resource migration.
+
+**Signature change (compile break per renamed field).** Where the official spec uses a different field name
+from the legacy one, the generated struct adopts the spec name. Each rename is documented in this file when
+it lands.
+
+Migration: compile-error-driven; rename at each call site.
+
+**Provenance:** epic #117, per-resource OpenAPI migration.
+
+### 6. New `integration/v1` `APIStyle` (deferred to 3.0.0)
+
+**Status: PENDING** — routing generated resources through the official `integration/v1` API is part of
+the OpenAPI generator wave (same milestone as rows 4/5); not yet landed.
+
+**Interface change (compile break for custom `Client` implementations).** A new `APIStyle` constant will
+route code-generated resources through the UniFi official `integration/v1` API path instead of the legacy
+`/api/s/{site}/...` endpoints. The generated CRUD methods and their structs will adopt OpenAPI-derived
+shapes (see rows 4/5).
+
+The `integration/v1` path is a capability layered on the new-style API — it is not a fourth independent
+style alongside `V1`, `V2`, and `new-style`; see `unifi/api_paths.go` for the documented constraint.
+
+Note: the `Official()` accessor and the `integration/v1` info/sites vertical that **did** land in PR #119
+are documented in entries [D](#d-client-interface-split-into-internalclient--internalofficial-accessors-119)
+and [E](#e-official-api-unavailable-on-classicold-style-controllers-119) of the provenance index above.
+
+**Provenance:** epic #117, OpenAPI generator wave (issues TBD, same milestone as rows 4/5).

--- a/docs/2.0.0/breaking_changes.md
+++ b/docs/2.0.0/breaking_changes.md
@@ -334,9 +334,11 @@ c, err := unifi.NewClient(&unifi.ClientConfig{URL: "...", APIKey: "...", SkipSys
 method for HTTP PATCH requests, alongside the existing `Do`/`Get`/`Post`/`Put`/`Delete`.
 
 ```go
-// new in 2.0.0
-err := c.Patch(ctx, "s/default/rest/networkconf/<id>", patchBody, &resp)
+// new in 2.0.0 — target endpoint must accept PATCH (e.g. the Official integration/v1 surface)
+err := c.Patch(ctx, "/proxy/network/integration/v1/sites/<id>/...", patchBody, &resp)
 ```
+
+`Patch` sends a literal HTTP PATCH; most legacy Internal REST resources (e.g. `networkconf`) expect `PUT`.
 
 **Provenance:** unifi/requests.go; delegated from epic #117, issue #148.
 
@@ -345,9 +347,10 @@ err := c.Patch(ctx, "s/default/rest/networkconf/<id>", patchBody, &resp)
 ## Planned for 3.0.0
 
 The following changes from the original epic #117 13-row index are **not** landing in 2.0.0. They are
-deferred to the next major version.
+deferred to the next major version. They keep their original epic-row numbers under a `P` (planned) prefix
+so they don't collide with the renumbered landed rows 4–6 above.
 
-### 4. OpenAPI-shaped structs (deferred to 3.0.0)
+### P4. OpenAPI-shaped structs (originally epic-row 4; deferred to 3.0.0)
 
 **Status: PENDING** — no resources migrated yet; landing per-resource as part of the OpenAPI generator wave.
 
@@ -359,7 +362,7 @@ Migration: compile against the new module version; fix any field references repo
 
 **Provenance:** epic #117, OpenAPI-generator wave (issues TBD).
 
-### 5. Occasional field renames (deferred to 3.0.0)
+### P5. Occasional field renames (originally epic-row 5; deferred to 3.0.0)
 
 **Status: PENDING** — no field renames yet; land alongside each OpenAPI-driven resource migration.
 
@@ -371,15 +374,15 @@ Migration: compile-error-driven; rename at each call site.
 
 **Provenance:** epic #117, per-resource OpenAPI migration.
 
-### 6. New `integration/v1` `APIStyle` (deferred to 3.0.0)
+### P6. New `integration/v1` `APIStyle` (originally epic-row 6; deferred to 3.0.0)
 
 **Status: PENDING** — routing generated resources through the official `integration/v1` API is part of
-the OpenAPI generator wave (same milestone as rows 4/5); not yet landed.
+the OpenAPI generator wave (same milestone as rows P4/P5); not yet landed.
 
 **Interface change (compile break for custom `Client` implementations).** A new `APIStyle` constant will
 route code-generated resources through the UniFi official `integration/v1` API path instead of the legacy
 `/api/s/{site}/...` endpoints. The generated CRUD methods and their structs will adopt OpenAPI-derived
-shapes (see rows 4/5).
+shapes (see rows P4/P5).
 
 The `integration/v1` path is a capability layered on the new-style API — it is not a fourth independent
 style alongside `V1`, `V2`, and `new-style`; see `unifi/api_paths.go` for the documented constraint.
@@ -388,4 +391,4 @@ Note: the `Official()` accessor and the `integration/v1` info/sites vertical tha
 are documented in entries [D](#d-client-interface-split-into-internalclient--internalofficial-accessors-119)
 and [E](#e-official-api-unavailable-on-classicold-style-controllers-119) of the provenance index above.
 
-**Provenance:** epic #117, OpenAPI generator wave (issues TBD, same milestone as rows 4/5).
+**Provenance:** epic #117, OpenAPI generator wave (issues TBD, same milestone as rows P4/P5).

--- a/docs/2.0.0/migration_guide.md
+++ b/docs/2.0.0/migration_guide.md
@@ -9,6 +9,26 @@ You don't need to keep [breaking_changes.md](breaking_changes.md) open while rea
 rationale and affected symbols are inlined here. That document is a cross-reference for completeness;
 this one is your hands-on guide.
 
+## Table of Contents
+
+- [Fast path](#fast-path)
+- [Authentication & TLS](#authentication--tls)
+  - [API key replaces username/password](#api-key-replaces-usernamepassword)
+  - [TLS verification now ON by default](#tls-verification-now-on-by-default)
+  - [CSRF handling removed](#csrf-handling-removed)
+- [Go version](#go-version)
+- [Client interface additions](#client-interface-additions)
+- [Error handling](#error-handling)
+  - [`meta.rc=="error"` on HTTP 200 now surfaces as `*ServerError`](#metarcerror-on-http-200-now-surfaces-as-servererror)
+  - [404 responses now satisfy `errors.Is(err, ErrNotFound)`](#404-responses-now-satisfy-errorsiserr-errnotfound)
+  - [`Create`/`Update` no longer return `ErrNotFound` on unexpected responses](#createupdate-no-longer-return-errnotfound-on-unexpected-responses)
+- [Types and methods](#types-and-methods)
+  - [`NewBareClient` replaced by `NewClient` with `SkipSystemInfo: true`](#newbareclient-replaced-by-newclient-with-skipsysteminfo-true)
+  - [New `Patch` method](#new-patch-method)
+  - [`UseLocking` is a no-op](#uselocking-is-a-no-op)
+- [Official API surface (additive)](#official-api-surface-additive)
+- [Further reading](#further-reading)
+
 ---
 
 ## Fast path
@@ -24,7 +44,6 @@ Mechanical checklist — tick each off in order:
 - [ ] Replace `NewBareClient(cfg)` with `NewClient(cfg)` + `SkipSystemInfo: true`
 - [ ] Review error checks on `Create`/`Update` paths (no longer returns `ErrNotFound`)
 - [ ] If your code implements the `Client` interface, add `SetSetting`, `VersionContext`, and `GetSystemInformationContext`
-- [ ] If you reference `Device.QOSProfile` directly, update to the pointer type (`*DeviceQOSProfile`)
 - [ ] Remove any direct use of `CSRFInterceptor` or `CsrfHeader`
 
 ---
@@ -45,14 +64,14 @@ the path Ubiquiti is investing in. Removing the fallback keeps the auth surface 
 ```go
 // before
 cfg := &unifi.ClientConfig{
-    BaseURL:  "https://unifi.localdomain", // before
-    User:     "admin",                     // before
-    Password: "secret",                    // before
+    BaseURL:  "https://unifi.localdomain",
+    User:     "admin",
+    Password: "secret",
 }
 // after
 cfg := &unifi.ClientConfig{
-    URL:    "https://unifi.localdomain", // after
-    APIKey: "your-api-key",             // after — obtain from Control Plane → Admins & Users
+    URL:    "https://unifi.localdomain",
+    APIKey: "your-api-key", // obtain from Control Plane → Admins & Users
 }
 ```
 
@@ -75,10 +94,10 @@ The renamed, inverted field means safe code requires no action; unsafe code is e
 
 ```go
 // before — zero value silently skipped verification
-cfg := &unifi.ClientConfig{VerifySSL: false} // before — verification OFF
+cfg := &unifi.ClientConfig{VerifySSL: false} // verification OFF
 
 // after — zero value verifies; set true only for self-signed certs
-cfg := &unifi.ClientConfig{SkipVerifySSL: true} // after — disable for self-signed cert (logs a warning)
+cfg := &unifi.ClientConfig{SkipVerifySSL: true} // disable for self-signed cert (logs a warning)
 ```
 
 **Check your code.** `grep -r 'VerifySSL' .` — any hit that set `VerifySSL: false` was getting no TLS
@@ -97,7 +116,7 @@ session cookies, so CSRF management is irrelevant.
 
 ```go
 // before
-c.AddInterceptor(&unifi.CSRFInterceptor{}) // before — no-op now; type is gone
+c.AddInterceptor(&unifi.CSRFInterceptor{}) // no-op now; type is gone
 // after — simply remove the line
 ```
 
@@ -221,31 +240,6 @@ _, err = c.CreateNetwork(ctx, "default", n)
 
 ## Types and methods
 
-### `Device.QOSProfile` changed from value to pointer
-
-**What changed.** `Device.QOSProfile` was `DeviceQOSProfile` (value). It is now `*DeviceQOSProfile`
-(pointer). The field is set to `nil` when absent from the API response.
-
-**Why.** The UniFi API omits the `qos_profile` key entirely when it isn't configured. A pointer type
-lets the SDK express "not set" (nil) vs "set to the zero value" — the value type forced callers to
-inspect inner fields to distinguish the two cases.
-
-```go
-// before
-profile := device.QOSProfile         // DeviceQOSProfile value
-mode := device.QOSProfile.QOSProfileMode
-
-// after
-if device.QOSProfile != nil {         // check nil first
-    mode := device.QOSProfile.QOSProfileMode
-}
-```
-
-**Check your code.** `grep -r 'QOSProfile' .` — any code that reads `device.QOSProfile` without a nil
-check will now panic. Add the nil guard.
-
----
-
 ### `NewBareClient` replaced by `NewClient` with `SkipSystemInfo: true`
 
 **What changed.** The `NewBareClient` function is removed. Its purpose was to create a client without
@@ -304,10 +298,10 @@ underlying HTTP client became goroutine-safe.
 
 ```go
 // before — had an effect (serialised requests)
-cfg := &unifi.ClientConfig{UseLocking: true} // before
+cfg := &unifi.ClientConfig{UseLocking: true}
 
 // after — field retained for source compat but ignored; remove it
-cfg := &unifi.ClientConfig{} // after — concurrent by default
+cfg := &unifi.ClientConfig{} // concurrent by default
 ```
 
 **Check your code.** `grep -r 'UseLocking' .` — you can remove the field; setting it has no effect.

--- a/docs/2.0.0/migration_guide.md
+++ b/docs/2.0.0/migration_guide.md
@@ -16,6 +16,7 @@ this one is your hands-on guide.
   - [API key replaces username/password](#api-key-replaces-usernamepassword)
   - [TLS verification now ON by default](#tls-verification-now-on-by-default)
   - [CSRF handling removed](#csrf-handling-removed)
+- [Official API surface (additive, recommended)](#official-api-surface-additive-recommended)
 - [Go version](#go-version)
 - [Client interface additions](#client-interface-additions)
 - [Error handling](#error-handling)
@@ -26,7 +27,6 @@ this one is your hands-on guide.
   - [`NewBareClient` replaced by `NewClient` with `SkipSystemInfo: true`](#newbareclient-replaced-by-newclient-with-skipsysteminfo-true)
   - [New `Patch` method](#new-patch-method)
   - [`UseLocking` is a no-op](#uselocking-is-a-no-op)
-- [Official API surface (additive)](#official-api-surface-additive)
 - [Further reading](#further-reading)
 
 ---
@@ -121,6 +121,38 @@ c.AddInterceptor(&unifi.CSRFInterceptor{}) // no-op now; type is gone
 ```
 
 **Check your code.** `grep -r 'CSRFInterceptor\|CsrfHeader' .`
+
+---
+
+## Official API surface (additive, recommended)
+
+**Recommended.** The Official API (`integration/v1`) is the surface Ubiquiti now maintains as a
+versioned, stable contract. **Prefer it over the legacy Internal API, and migrate existing Internal
+calls to their Official equivalents wherever a covered one exists.** The Internal surface stays
+supported for everything the Official API doesn't yet cover, but new code should reach for
+`c.Official()` first.
+
+**What changed.** `c.Official()` returns a fluent client for the UniFi official OpenAPI
+(`integration/v1`). This is new in 2.0.0 and is purely additive — no existing code changes.
+
+**Why.** Ubiquiti now ships a versioned, stable OpenAPI specification. The Official surface lets you
+use it without touching the Internal API.
+
+```go
+// Official API — new in 2.0.0; requires controller ≥ 10.1.78 with API-key auth
+info, err := c.Official().Info().Get(ctx)
+id, err := c.Official().Sites().ResolveID(ctx, "default") // legacy name → UUID
+
+page, err := c.Official().Networks().ListPage(ctx, id, nil)
+pol, err := c.Official().Firewall().CreatePolicy(ctx, id, body)
+```
+
+Operations on `c.Official()` return `ErrOfficialAPIUnavailable` if the controller is below `10.1.78`,
+is old-style, or uses non-API-key auth. Set `DisableOfficialAPI: true` in `ClientConfig` to opt out
+entirely (operations then fail fast with `ErrOfficialAPIDisabled`).
+
+In 2.0.0 the Internal surface remains the default — calling a resource method directly on `c` is
+identical to calling it on `c.Internal()`. The default is expected to flip to Official in 3.0.0.
 
 ---
 
@@ -305,32 +337,6 @@ cfg := &unifi.ClientConfig{} // concurrent by default
 ```
 
 **Check your code.** `grep -r 'UseLocking' .` — you can remove the field; setting it has no effect.
-
----
-
-## Official API surface (additive)
-
-**What changed.** `c.Official()` returns a fluent client for the UniFi official OpenAPI
-(`integration/v1`). This is new in 2.0.0 and is purely additive — no existing code changes.
-
-**Why.** Ubiquiti now ships a versioned, stable OpenAPI specification. The Official surface lets you
-use it without touching the Internal API.
-
-```go
-// Official API — new in 2.0.0; requires controller ≥ 10.1.78 with API-key auth
-info, err := c.Official().Info().Get(ctx)
-id, err := c.Official().Sites().ResolveID(ctx, "default") // legacy name → UUID
-
-page, err := c.Official().Networks().ListPage(ctx, id, nil)
-pol, err := c.Official().Firewall().CreatePolicy(ctx, id, body)
-```
-
-Operations on `c.Official()` return `ErrOfficialAPIUnavailable` if the controller is below `10.1.78`,
-is old-style, or uses non-API-key auth. Set `DisableOfficialAPI: true` in `ClientConfig` to opt out
-entirely (operations then fail fast with `ErrOfficialAPIDisabled`).
-
-In 2.0.0 the Internal surface remains the default — calling a resource method directly on `c` is
-identical to calling it on `c.Internal()`. The default is expected to flip to Official in 3.0.0.
 
 ---
 

--- a/docs/2.0.0/migration_guide.md
+++ b/docs/2.0.0/migration_guide.md
@@ -109,8 +109,9 @@ c.AddInterceptor(&unifi.CSRFInterceptor{}) // before — no-op now; type is gone
 
 **What changed.** The module requires Go 1.26 or later (`go 1.26.0` in `go.mod`).
 
-**Why.** The Official API surface uses range-over-func iterators (`iter.Seq2`) which were stabilised in
-Go 1.23. 1.26 is the current stable version that gives us a safe minimum with no surprises.
+**Why.** The Official API surface uses range-over-func iterators (`iter.Seq2`), which need Go ≥ 1.23. The
+module pins `1.26` as the project's supported toolchain baseline (the `go` directive in `go.mod`) — not
+because any single language feature demands it — so contributors and consumers build on one known-good floor.
 
 **Check your code.** Run `go version` — if you're below 1.26 you'll see a build error immediately. Update
 your toolchain (`go install golang.org/dl/go1.26.0@latest && go1.26.0 download`).
@@ -277,16 +278,19 @@ c, err := unifi.NewClient(&unifi.ClientConfig{
 **What changed.** The `Client` interface (and the concrete `*client`) now exposes a `Patch` method
 alongside the existing `Get`/`Post`/`Put`/`Delete`. It sends an HTTP PATCH request for partial updates.
 
-**Why.** The UniFi Official API uses PATCH for partial resource updates; adding it to the escape-hatch
-surface keeps parity.
+**Why.** PATCH is the standard verb for partial updates, and the escape-hatch surface (`Do`/`Get`/`Post`/
+`Put`/`Delete`) was missing it. It is most useful against endpoints that actually accept PATCH — notably
+the Official `integration/v1` surface and any new-style endpoint documented to support partial updates.
 
 ```go
-// new in 2.0.0 — partial update via PATCH
+// new in 2.0.0 — partial update via PATCH against a PATCH-capable endpoint
 patch := struct{ Name string `json:"name"` }{Name: "updated"}
-err := c.Patch(ctx, "s/default/rest/networkconf/<id>", patch, &resp)
+err := c.Patch(ctx, "/proxy/network/integration/v1/sites/<id>/...", patch, &resp)
 ```
 
-This is an additive change — no existing code is broken.
+`Patch` sends a literal HTTP PATCH — the target endpoint must accept it. Most legacy Internal REST
+resources (e.g. `networkconf`) expect `PUT`; use `Put` for those. This is an additive change — no
+existing code is broken.
 
 ---
 

--- a/docs/2.0.0/migration_guide.md
+++ b/docs/2.0.0/migration_guide.md
@@ -60,7 +60,7 @@ cfg := &unifi.ClientConfig{
 - `grep -r 'User:\|Username:\|Password:\|RememberMe:\|UserPassCredentials' .`
 - `grep -r '\.Login(\|\.Logout(' .`
 
-API keys require UniFi Network 9.0.108 or newer on a UniFi OS (new-style) controller.
+API keys require UniFi Network 9.0.114 or newer on a UniFi OS (new-style) controller.
 
 ---
 

--- a/docs/2.0.0/migration_guide.md
+++ b/docs/2.0.0/migration_guide.md
@@ -1,0 +1,345 @@
+# go-unifi 1.x → 2.0 Migration Guide
+
+This guide walks you through every breaking change introduced in go-unifi 2.0.0. It is written for
+Go developers of all experience levels: a senior can skim the **Fast path** checklist and be done in
+minutes; a junior can read each thematic section for the full story of what changed, why, and what
+to look for in their own code.
+
+You don't need to keep [breaking_changes.md](breaking_changes.md) open while reading this — all the
+rationale and affected symbols are inlined here. That document is a cross-reference for completeness;
+this one is your hands-on guide.
+
+---
+
+## Fast path
+
+Mechanical checklist — tick each off in order:
+
+- [ ] Update the import path to `/v2`: `github.com/filipowm/go-unifi/v2/unifi`
+- [ ] Update `go get`: `go get github.com/filipowm/go-unifi/v2`
+- [ ] Replace `ClientConfig.User`/`Username`/`Password`/`RememberMe` with `APIKey:`
+- [ ] Remove any calls to `.Login()`, `.LoginContext()`, `.Logout()`, `.LogoutContext()`
+- [ ] Rename `VerifySSL: false` → `SkipVerifySSL: true` (and double-check the logic flip — verify is now ON by default)
+- [ ] Update your Go toolchain to Go 1.26 or newer
+- [ ] Replace `NewBareClient(cfg)` with `NewClient(cfg)` + `SkipSystemInfo: true`
+- [ ] Review error checks on `Create`/`Update` paths (no longer returns `ErrNotFound`)
+- [ ] If your code implements the `Client` interface, add `SetSetting`, `VersionContext`, and `GetSystemInformationContext`
+- [ ] If you reference `Device.QOSProfile` directly, update to the pointer type (`*DeviceQOSProfile`)
+- [ ] Remove any direct use of `CSRFInterceptor` or `CsrfHeader`
+
+---
+
+## Authentication & TLS
+
+### API key replaces username/password
+
+**What changed.** Username/password authentication is gone. The `ClientConfig` fields
+`User`/`Username`/`Password`/`RememberMe` and the type `UserPassCredentials` no longer exist. The
+`Login`/`LoginContext`/`Logout`/`LogoutContext` methods are removed from the `Client` interface.
+Old-style (classic) controllers — which only ever supported user/pass — are also unsupported; constructing
+a client against one returns `ErrOldStyleUnsupported` immediately.
+
+**Why.** API keys are more secure (no session expiry, no CSRF exposure, scoped credentials) and are
+the path Ubiquiti is investing in. Removing the fallback keeps the auth surface small and predictable.
+
+```go
+// before
+cfg := &unifi.ClientConfig{
+    BaseURL:  "https://unifi.localdomain", // before
+    User:     "admin",                     // before
+    Password: "secret",                    // before
+}
+// after
+cfg := &unifi.ClientConfig{
+    URL:    "https://unifi.localdomain", // after
+    APIKey: "your-api-key",             // after — obtain from Control Plane → Admins & Users
+}
+```
+
+**Check your code.**
+- `grep -r 'User:\|Username:\|Password:\|RememberMe:\|UserPassCredentials' .`
+- `grep -r '\.Login(\|\.Logout(' .`
+
+API keys require UniFi Network 9.0.108 or newer on a UniFi OS (new-style) controller.
+
+---
+
+### TLS verification now ON by default
+
+**What changed.** `ClientConfig.VerifySSL bool` was renamed **and inverted** to `SkipVerifySSL bool`.
+The zero value now means *verify certificates* (secure by default). In 1.x the zero value `VerifySSL: false`
+meant *skip verification* — the exact opposite.
+
+**Why.** The old name was a footgun: leaving it at zero gave you an insecure connection by accident.
+The renamed, inverted field means safe code requires no action; unsafe code is explicit and logged at WARN.
+
+```go
+// before — zero value silently skipped verification
+cfg := &unifi.ClientConfig{VerifySSL: false} // before — verification OFF
+
+// after — zero value verifies; set true only for self-signed certs
+cfg := &unifi.ClientConfig{SkipVerifySSL: true} // after — disable for self-signed cert (logs a warning)
+```
+
+**Check your code.** `grep -r 'VerifySSL' .` — any hit that set `VerifySSL: false` was getting no TLS
+verification and will now get full verification (good for most callers). If your controller uses a
+self-signed cert you must add `SkipVerifySSL: true`.
+
+---
+
+### CSRF handling removed
+
+**What changed.** With username/password auth gone (above), the `CSRFInterceptor` and its token logic
+are removed. The `CsrfHeader` constant is also gone.
+
+**Why.** CSRF tokens were session-cookie artifacts tied to user/pass auth. API-key auth doesn't use
+session cookies, so CSRF management is irrelevant.
+
+```go
+// before
+c.AddInterceptor(&unifi.CSRFInterceptor{}) // before — no-op now; type is gone
+// after — simply remove the line
+```
+
+**Check your code.** `grep -r 'CSRFInterceptor\|CsrfHeader' .`
+
+---
+
+## Go version
+
+**What changed.** The module requires Go 1.26 or later (`go 1.26.0` in `go.mod`).
+
+**Why.** The Official API surface uses range-over-func iterators (`iter.Seq2`) which were stabilised in
+Go 1.23. 1.26 is the current stable version that gives us a safe minimum with no surprises.
+
+**Check your code.** Run `go version` — if you're below 1.26 you'll see a build error immediately. Update
+your toolchain (`go install golang.org/dl/go1.26.0@latest && go1.26.0 download`).
+
+---
+
+## Client interface additions
+
+**What changed.** The `Client` interface has three new methods. If you maintain a custom type that
+implements `Client` (rare — most callers use the concrete `*client` returned by `NewClient`), you
+must add these:
+
+```go
+// Added — implement all three if you have a custom Client implementation
+SetSetting(ctx context.Context, site string, key string, reqBody any) (any, error)
+VersionContext(ctx context.Context) (string, error)
+GetSystemInformationContext(ctx context.Context) (*SysInfo, error)
+```
+
+Note: `LoginContext`/`LogoutContext` were briefly added and then removed (with all of auth row #1 above).
+
+**Why.** `SetSetting` was on the concrete struct but missing from the interface. The `*Context` variants
+add proper context propagation for callers who need cancellation/timeouts on lifecycle calls.
+
+**Check your code.** Only affects you if you have a type that satisfies `unifi.Client` by listing the
+methods (e.g. a hand-written mock). The generated `ClientMock` (moq) is regenerated automatically.
+
+---
+
+## Error handling
+
+### `meta.rc=="error"` on HTTP 200 now surfaces as `*ServerError`
+
+**What changed.** The UniFi v1 API sometimes returns HTTP 200 with `meta.rc == "error"` — a soft
+application-level failure. In 1.x this was caught in exactly one place (`CreateUser`) and silently
+swallowed everywhere else. In 2.0.0 it is detected centrally in `handleResponse`, so **every**
+decoded `{meta,data}` 200 with `rc=="error"` surfaces as a `*ServerError` carrying the controller's
+`rc`/`msg`, enriched with status/method/URL.
+
+**Why.** Silent swallowing of soft errors was a correctness hazard. Surfacing them uniformly lets
+callers make explicit decisions.
+
+```go
+// before — rc=="error" 200 swallowed silently for most resources
+err := c.CreateNetwork(ctx, "default", n)
+// err could be nil even when the controller reported an application error
+
+// after — same code; rc=="error" now produces *ServerError
+var serverErr *unifi.ServerError
+if errors.As(err, &serverErr) {
+    log.Printf("controller error: %s", serverErr.Message)
+}
+```
+
+**Check your code.** If you have error checks that assumed success whenever `err == nil` after a resource
+call, they are now correct. If you specifically checked for `nil` and then inspected the response body
+yourself, you can remove that logic.
+
+---
+
+### 404 responses now satisfy `errors.Is(err, ErrNotFound)`
+
+**What changed.** Previously only hand-written list/get wrappers returned `ErrNotFound`. In 2.0.0,
+`(*ServerError).Is` maps any `*ServerError` with `StatusCode == 404` to the `ErrNotFound` sentinel,
+so a genuine HTTP 404 from **any** endpoint satisfies `errors.Is(err, unifi.ErrNotFound)`.
+
+**Why.** Consistent error semantics: "not found" means `ErrNotFound`, regardless of which endpoint
+produced the 404.
+
+```go
+// before/after — same check; now covers all 404s, not just specific resources
+if errors.Is(err, unifi.ErrNotFound) {
+    // resource doesn't exist
+}
+```
+
+**Check your code.** If you were checking `err != nil && !errors.Is(err, ErrNotFound)` on create/get
+paths, the behavior is now wider — any 404 will match. This is correct and desirable.
+
+---
+
+### `Create`/`Update` no longer return `ErrNotFound` on unexpected responses
+
+**What changed.** The v1-REST template used to return `ErrNotFound` when a successful create/update
+response contained a data array with a length other than 1. That was semantically wrong (you just
+created something — it can't "not be found"). In 2.0.0 these return a descriptive error instead:
+`fmt.Errorf("unexpected response: expected 1 <X>, got %d", n)`.
+
+**Why.** `ErrNotFound` should only mean "the resource doesn't exist at that path." Using it on a
+create path confused callers and hid real bugs.
+
+```go
+// before — ErrNotFound could (incorrectly) come back from a create
+_, err := c.CreateNetwork(ctx, "default", n)
+if errors.Is(err, unifi.ErrNotFound) { /* this branch could fire on create */ }
+
+// after — ErrNotFound will NOT come from Create/Update
+_, err = c.CreateNetwork(ctx, "default", n)
+// non-nil err means failure; errors.Is(err, ErrNotFound) is always false here
+```
+
+**Check your code.** `grep -r 'ErrNotFound' .` — any `errors.Is(err, ErrNotFound)` that sits on a
+`Create`/`Update` call path was dead code (the controller was returning an application error, not a
+404). Remove those branches or replace with a generic `err != nil` check.
+
+---
+
+## Types and methods
+
+### `Device.QOSProfile` changed from value to pointer
+
+**What changed.** `Device.QOSProfile` was `DeviceQOSProfile` (value). It is now `*DeviceQOSProfile`
+(pointer). The field is set to `nil` when absent from the API response.
+
+**Why.** The UniFi API omits the `qos_profile` key entirely when it isn't configured. A pointer type
+lets the SDK express "not set" (nil) vs "set to the zero value" — the value type forced callers to
+inspect inner fields to distinguish the two cases.
+
+```go
+// before
+profile := device.QOSProfile         // DeviceQOSProfile value
+mode := device.QOSProfile.QOSProfileMode
+
+// after
+if device.QOSProfile != nil {         // check nil first
+    mode := device.QOSProfile.QOSProfileMode
+}
+```
+
+**Check your code.** `grep -r 'QOSProfile' .` — any code that reads `device.QOSProfile` without a nil
+check will now panic. Add the nil guard.
+
+---
+
+### `NewBareClient` replaced by `NewClient` with `SkipSystemInfo: true`
+
+**What changed.** The `NewBareClient` function is removed. Its purpose was to create a client without
+the eager `GetSystemInformation()` round-trip. You now do this with the standard `NewClient` and the
+`SkipSystemInfo: true` field.
+
+**Why.** A separate constructor created two code paths to maintain. The `SkipSystemInfo` field achieves
+the same behaviour without the duplication.
+
+```go
+// before
+c, err := unifi.NewBareClient(&unifi.ClientConfig{
+    BaseURL: "https://unifi.localdomain",
+    APIKey:  "your-api-key",
+})
+// after
+c, err := unifi.NewClient(&unifi.ClientConfig{
+    URL:            "https://unifi.localdomain",
+    APIKey:         "your-api-key",
+    SkipSystemInfo: true, // skip the eager sysinfo check; errors surface on first API call
+})
+```
+
+**Check your code.** `grep -r 'NewBareClient' .`
+
+---
+
+### New `Patch` method
+
+**What changed.** The `Client` interface (and the concrete `*client`) now exposes a `Patch` method
+alongside the existing `Get`/`Post`/`Put`/`Delete`. It sends an HTTP PATCH request for partial updates.
+
+**Why.** The UniFi Official API uses PATCH for partial resource updates; adding it to the escape-hatch
+surface keeps parity.
+
+```go
+// new in 2.0.0 — partial update via PATCH
+patch := struct{ Name string `json:"name"` }{Name: "updated"}
+err := c.Patch(ctx, "s/default/rest/networkconf/<id>", patch, &resp)
+```
+
+This is an additive change — no existing code is broken.
+
+---
+
+### `UseLocking` is a no-op
+
+**What changed.** `ClientConfig.UseLocking` is deprecated and has no effect. `net/http.Client` is
+goroutine-safe; requests run concurrently and are not serialized.
+
+**Why.** The old mutex serialisation was a performance hazard with no correctness benefit once the
+underlying HTTP client became goroutine-safe.
+
+```go
+// before — had an effect (serialised requests)
+cfg := &unifi.ClientConfig{UseLocking: true} // before
+
+// after — field retained for source compat but ignored; remove it
+cfg := &unifi.ClientConfig{} // after — concurrent by default
+```
+
+**Check your code.** `grep -r 'UseLocking' .` — you can remove the field; setting it has no effect.
+
+---
+
+## Official API surface (additive)
+
+**What changed.** `c.Official()` returns a fluent client for the UniFi official OpenAPI
+(`integration/v1`). This is new in 2.0.0 and is purely additive — no existing code changes.
+
+**Why.** Ubiquiti now ships a versioned, stable OpenAPI specification. The Official surface lets you
+use it without touching the Internal API.
+
+```go
+// Official API — new in 2.0.0; requires controller ≥ 10.1.78 with API-key auth
+info, err := c.Official().Info().Get(ctx)
+id, err := c.Official().Sites().ResolveID(ctx, "default") // legacy name → UUID
+
+page, err := c.Official().Networks().ListPage(ctx, id, nil)
+pol, err := c.Official().Firewall().CreatePolicy(ctx, id, body)
+```
+
+Operations on `c.Official()` return `ErrOfficialAPIUnavailable` if the controller is below `10.1.78`,
+is old-style, or uses non-API-key auth. Set `DisableOfficialAPI: true` in `ClientConfig` to opt out
+entirely (operations then fail fast with `ErrOfficialAPIDisabled`).
+
+In 2.0.0 the Internal surface remains the default — calling a resource method directly on `c` is
+identical to calling it on `c.Internal()`. The default is expected to flip to Official in 3.0.0.
+
+---
+
+## Further reading
+
+- [breaking_changes.md](breaking_changes.md) — authoritative changelog with status, provenance, and
+  code snippets for every break
+- [compatibility_matrix.md](../compatibility_matrix.md) — go-unifi release ↔ controller version matrix
+- [advanced_topics.md](../advanced_topics.md) — raw API calls (`Do`/`Get`/`Post`/`Put`/`Patch`/`Delete`),
+  path-resolution rules, interceptors

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -69,7 +69,9 @@ if err != nil {
 // do something with the response
 ```
 
-For a partial update (PATCH), pass only the fields you want to change:
+For a partial update (PATCH), pass only the fields you want to change. `Patch` sends a literal HTTP PATCH,
+so the target endpoint must accept it — the Official `integration/v1` surface does; most legacy Internal
+REST resources (e.g. `networkconf`) expect `PUT`, so use `Put` for those:
 
 ```go
 patch := struct {
@@ -81,7 +83,8 @@ var patchResp struct {
     Data interface{} `json:"data"`
 }
 
-err = c.Patch(ctx, "s/default/rest/networkconf/<id>", patch, &patchResp)
+// Absolute path (leading slash) ⇒ sent as-is; PATCH-capable endpoint
+err = c.Patch(ctx, "/proxy/network/integration/v1/sites/<id>/...", patch, &patchResp)
 if err != nil {
     log.Fatalf("Error performing PATCH request: %v", err)
 }

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -13,10 +13,25 @@ by handling common tasks such as request construction, JSON marshaling of the re
 - **Get**: A convenience wrapper around **Do** that executes an HTTP GET request.
 - **Post**: A convenience wrapper to perform an HTTP POST request.
 - **Put**: Similar to Post, but for HTTP PUT requests.
+- **Patch**: A convenience wrapper to perform an HTTP PATCH request (partial update).
 - **Delete**: Performs an HTTP DELETE request.
 
 These methods are used internally by higher level functions, such as those in `unifi/device.generated.go` and `unifi/device.go`. For example, when creating a new device, the SDK calls `Post` to send
 the device data to the UniFi Controller API, while `Get` is used to retrieve device information.
+
+### Path resolution
+
+The `apiPath` argument follows a simple rule (see `unifi/requests.go` `buildRequestURL`):
+
+- **No leading slash (site-relative):** the path is prefixed with the controller's base API prefix. On
+  new-style (UniFi OS) controllers — the **only** style supported in 2.0.0 — that prefix is
+  `/proxy/network/api`. Example: `"s/default/rest/networkconf"` → `/proxy/network/api/s/default/rest/networkconf`.
+- **Leading slash or absolute URL:** used **as-is**, bypassing the prefix entirely. Use this only when
+  you deliberately need a path outside the standard API tree (e.g. `/proxy/network/integration/v1/...`).
+  The old `/api/...` form that worked on classic controllers **does not work** on new-style controllers;
+  use the site-relative form instead.
+
+### Examples
 
 Here is an example of using these methods for a custom API operation:
 
@@ -27,8 +42,8 @@ var respData struct {
     Data interface{} `json:"data"`
 }
 
-// Use the Get method to fetch data from a custom endpoint
-err := c.Get(ctx, "/api/customEndpoint", nil, &respData)
+// Use the Get method to fetch data from a custom endpoint (site-relative path)
+err := c.Get(ctx, "s/default/rest/networkconf", nil, &respData)
 if err != nil {
     log.Fatalf("Error performing GET request: %v", err)
 }
@@ -47,11 +62,29 @@ var postResp struct {
     Data interface{} `json:"data"`
 }
 
-err = c.Post(ctx, "/api/customPostEndpoint", reqPayload, &postResp)
+err = c.Post(ctx, "s/default/rest/networkconf", reqPayload, &postResp)
 if err != nil {
     log.Fatalf("Error performing POST request: %v", err)
 }
 // do something with the response
+```
+
+For a partial update (PATCH), pass only the fields you want to change:
+
+```go
+patch := struct {
+    Name string `json:"name"`
+}{Name: "updated-name"}
+
+var patchResp struct {
+    Meta Meta        `json:"meta"`
+    Data interface{} `json:"data"`
+}
+
+err = c.Patch(ctx, "s/default/rest/networkconf/<id>", patch, &patchResp)
+if err != nil {
+    log.Fatalf("Error performing PATCH request: %v", err)
+}
 ```
 
 These helper methods abstract away the boilerplate of manually constructing HTTP requests and processing responses, allowing you to focus on your application's logic while leveraging built-in
@@ -60,7 +93,7 @@ validation and error handling provided by the SDK.
 ## Interceptors and Middleware
 
 Interceptors provide hooks into the request/response cycle and can be used for logging, metrics collection, or modifying
-requests before they are sent. They implement the [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/unifi#ClientInterceptor) interface.
+requests before they are sent. They implement the [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientInterceptor) interface.
 
 ### Example: Advanced Logging Interceptor
 
@@ -83,8 +116,8 @@ func (a *AdvancedLoggingInterceptor) InterceptResponse(resp *http.Response) erro
 }
 
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    APIKey: "your-api-key",
+    URL:          "https://unifi.localdomain",
+    APIKey:       "your-api-key",
     Interceptors: []unifi.ClientInterceptor{&AdvancedLoggingInterceptor{}},
 })
 if err != nil {

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -2,18 +2,27 @@
 
 This table maps `go-unifi` library releases to the range of UniFi Network Controller versions they are known to work with.
 
-| `go-unifi` version  | Min UniFi Controller | Latest UniFi Controller |
-|---------------------|----------------------|-------------------------|
-| `1.11.0`            | `5.12.35`            | `9.5.21`                |
-| `1.10.0`            | `5.12.35`            | `9.4.19`                |
-| `v1.9.0` – `v1.9.1` | `5.12.35`            | `9.3.45`                |
-| `v0.0.1` – `v1.8.1` | `5.12.35`            | `9.0.114`               |
+| `go-unifi` version  | Min UniFi Controller | Internal API version | Official API version |
+|---------------------|----------------------|----------------------|----------------------|
+| `2.0.0`             | `9.0.108`            | `9.5.21` (frozen)    | `10.1.78` (tracks spec) |
+| `1.11.0`            | `5.12.35`            | `9.5.21`             | —                    |
+| `1.10.0`            | `5.12.35`            | `9.4.19`             | —                    |
+| `v1.9.0` – `v1.9.1` | `5.12.35`            | `9.3.45`             | —                    |
+| `v0.0.1` – `v1.8.1` | `5.12.35`            | `9.0.114`            | —                    |
 
 > [!NOTE]
 > Only the **min** and **latest** versions listed above are explicitly verified. Versions in
 > between (and newer versions released after the latest tested one) are very likely supported as
 > well, but this is **not checked**. If you hit an issue on a specific controller version, please
 > [open an issue](https://github.com/filipowm/go-unifi/issues).
+
+**2.0.0 notes:**
+- The **minimum** controller version (9.0.108) is set by API-key authentication — the only supported auth.
+  Old-style (classic) controllers are unsupported (`ErrOldStyleUnsupported`).
+- The **Internal API** is frozen at `9.5.21` for 2.0.0. The daily version bump moves the `.unifi-version`
+  marker forward but the generated shapes won't diverge until the next major.
+- The **Official OpenAPI** surface (`c.Official()`) requires controller ≥ `10.1.78`. The spec version
+  (`.unifi-version-official`) tracks the latest committed snapshot and updates daily.
 
 The library is updated daily to track the latest UniFi Controller releases, so the "Latest" value moves forward over time.
 Two plain-text version markers are written at the repo root by `go generate`:
@@ -22,6 +31,12 @@ Two plain-text version markers are written at the repo root by `go generate`:
 - [`.unifi-version-official`](../.unifi-version-official) — the Official OpenAPI (`integration/v1`) spec version (requires controller ≥ `10.1.78`)
 
 ## Compatibility Changelog
+
+### 2.0.0 — Breaking changes
+
+See [docs/2.0.0/breaking_changes.md](2.0.0/breaking_changes.md) for the full list of 10 breaking changes.
+Key changes: API-key-only auth, TLS verify-by-default, Go 1.26+, `VerifySSL` → `SkipVerifySSL`, removed
+`Login`/`Logout`, `Device.QOSProfile` value → pointer, `NewBareClient` replaced by `SkipSystemInfo`.
 
 ### 1.11.0 / UniFi Controller 9.5.21
 

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -36,7 +36,7 @@ Two plain-text version markers are written at the repo root by `go generate`:
 
 See [docs/2.0.0/breaking_changes.md](2.0.0/breaking_changes.md) for the full list of 10 breaking changes.
 Key changes: API-key-only auth, TLS verify-by-default, Go 1.26+, `VerifySSL` → `SkipVerifySSL`, removed
-`Login`/`Logout`, `Device.QOSProfile` value → pointer, `NewBareClient` replaced by `SkipSystemInfo`.
+`Login`/`Logout`, `NewBareClient` replaced by `SkipSystemInfo`.
 
 ### 1.11.0 / UniFi Controller 9.5.21
 

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -4,7 +4,7 @@ This table maps `go-unifi` library releases to the range of UniFi Network Contro
 
 | `go-unifi` version  | Min UniFi Controller | Internal API version | Official API version |
 |---------------------|----------------------|----------------------|----------------------|
-| `2.0.0`             | `9.0.108`            | `9.5.21` (frozen)    | `10.1.78` (tracks spec) |
+| `2.0.0`             | `9.0.114`            | `9.5.21` (frozen)    | `10.1.78` (tracks spec) |
 | `1.11.0`            | `5.12.35`            | `9.5.21`             | —                    |
 | `1.10.0`            | `5.12.35`            | `9.4.19`             | —                    |
 | `v1.9.0` – `v1.9.1` | `5.12.35`            | `9.3.45`             | —                    |
@@ -17,7 +17,7 @@ This table maps `go-unifi` library releases to the range of UniFi Network Contro
 > [open an issue](https://github.com/filipowm/go-unifi/issues).
 
 **2.0.0 notes:**
-- The **minimum** controller version (9.0.108) is set by API-key authentication — the only supported auth.
+- The **minimum** controller version (9.0.114) is set by API-key authentication — the only supported auth.
   Old-style (classic) controllers are unsupported (`ErrOldStyleUnsupported`).
 - The **Internal API** is frozen at `9.5.21` for 2.0.0. The daily version bump moves the `.unifi-version`
   marker forward but the generated shapes won't diverge until the next major.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ The UniFi Go SDK client is highly configurable to cater to different needs and e
 
 The client uses **API Key authentication exclusively** (username/password was removed in 2.0.0). Obtain your
 key from the UniFi Network controller under Control Plane → Admins & Users → your admin user → Create API Key.
-Requires controller version 9.0.108 or newer.
+Requires controller version 9.0.114 or newer.
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,34 +2,16 @@
 
 The UniFi Go SDK client is highly configurable to cater to different needs and environments. This document explains the various configuration options available in the client.
 
-## Authentication Methods
+## Authentication
 
-The client supports two authentication protocols:
-
-### API Key Authentication
-
-Use this method for better security and dedicated access. Example:
+The client uses **API Key authentication exclusively** (username/password was removed in 2.0.0). Obtain your
+key from the UniFi Network controller under Control Plane → Admins & Users → your admin user → Create API Key.
+Requires controller version 9.0.108 or newer.
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
+    URL:    "https://unifi.localdomain",
     APIKey: "your-api-key",
-})
-if err != nil {
-    log.Fatalf("Error creating client: %v", err)
-}
-```
-
-### Username/Password Authentication
-
-Alternatively, you can use username and password:
-
-```go
-c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    Username: "your-username",
-    Password: "your-password",
-    RememberMe: true, // Optional: prolong the session validity. Might be needed for long-running applications.
 })
 if err != nil {
     log.Fatalf("Error creating client: %v", err)
@@ -48,8 +30,8 @@ Configure the validation mode as follows:
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    APIKey: "your-api-key",
+    URL:            "https://unifi.localdomain",
+    APIKey:         "your-api-key",
     ValidationMode: unifi.HardValidation,
 })
 if err != nil {
@@ -73,7 +55,7 @@ or TLS configurations:
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
+    URL:    "https://unifi.localdomain",
     APIKey: "your-api-key",
     HttpTransportCustomizer: func(transport *http.Transport) (*http.Transport, error) {
         transport.MaxIdleConns = 10
@@ -93,7 +75,7 @@ You can provide your own HTTP client configuration using the `HttpRoundTripperPr
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
+    URL:    "https://unifi.localdomain",
     APIKey: "your-api-key",
     HttpRoundTripperProvider: func() http.RoundTripper {
         // Create a custom HTTP Round Tripper instance
@@ -106,7 +88,7 @@ c, err := unifi.NewClient(&unifi.ClientConfig{
 
 Interceptors let you hook into the request and response flow. They can be used for logging, metrics, or modifying requests/responses.
 
-Implement the [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/unifi#ClientInterceptor) interface:
+Implement the [ClientInterceptor](https://pkg.go.dev/github.com/filipowm/go-unifi/v2/unifi#ClientInterceptor) interface:
 
 ```go
 // LoggingInterceptor logs each request and response
@@ -123,8 +105,8 @@ func (l *LoggingInterceptor) InterceptResponse(resp *http.Response) error {
 }
 
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    APIKey: "your-api-key",
+    URL:          "https://unifi.localdomain",
+    APIKey:       "your-api-key",
     Interceptors: []unifi.ClientInterceptor{&LoggingInterceptor{}},
 })
 if err != nil {
@@ -155,7 +137,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 )
 
 // customTransportCustomizer customizes the HTTP transport, e.g., setting idle connection limits and TLS options.
@@ -196,9 +178,7 @@ func main() {
 	// Create a comprehensive client configuration.
 	config := &unifi.ClientConfig{
 		URL:    "https://unifi.example.com", // Base URL of the UniFi controller (without trailing '/api')
-		APIKey: "your-api-key",              // API key for authentication. Alternatively, use User and Pass for user/password auth.
-		// User:         "username",                                 // Uncomment and provide if using user/password authentication
-		// Password:     "password",                                 // Uncomment and provide if using user/password authentication
+		APIKey: "your-api-key",              // API key for authentication (required; username/password removed in 2.0.0)
 		Timeout:        30 * time.Second,                                // Maximum duration to wait for a response
 		// SkipVerifySSL controls TLS verification and is SECURE BY DEFAULT: leave it false (the
 		// zero value) to verify certificates. Set it to true only for self-signed controller certs (logs a warning).

--- a/docs/file_uploads.md
+++ b/docs/file_uploads.md
@@ -22,15 +22,14 @@ import (
 	"context"
 	"log"
 
-	"github.com/filipowm/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 )
 
 func main() {
 	// Create a client
 	client, err := unifi.NewClient(&unifi.ClientConfig{
-		URL:      "https://your-unifi-controller:8443",
-		User:     "your-username",
-		Password: "your-password",
+		URL:    "https://your-unifi-controller:8443",
+		APIKey: "your-api-key",
 	})
 	if err != nil {
 		log.Fatalf("Error creating client: %v", err)
@@ -45,7 +44,7 @@ func main() {
 	var response map[string]interface{} // Adjust this type based on the expected response
 	err = client.UploadFile(
 		context.Background(),
-		"/api/s/default/upload", // The API endpoint to upload to
+		"s/default/upload", // The API endpoint path (site-relative; prefixed with /proxy/network/api)
 		"/path/to/your/file.txt", // Path to the file on disk
 		"file", // Form field name for the file
 		formFields, // Additional form fields
@@ -69,15 +68,14 @@ import (
 	"context"
 	"log"
 
-	"github.com/paultyng/go-unifi/unifi"
+	"github.com/filipowm/go-unifi/v2/unifi"
 )
 
 func main() {
 	// Create a client
 	client, err := unifi.NewClient(&unifi.ClientConfig{
-		URL:      "https://your-unifi-controller:8443",
-		User:     "your-username",
-		Password: "your-password",
+		URL:    "https://your-unifi-controller:8443",
+		APIKey: "your-api-key",
 	})
 	if err != nil {
 		log.Fatalf("Error creating client: %v", err)
@@ -91,7 +89,7 @@ func main() {
 	var response map[string]interface{} // Adjust this type based on the expected response
 	err = client.UploadFileFromReader(
 		context.Background(),
-		"/api/s/default/upload", // The API endpoint to upload to
+		"s/default/upload", // The API endpoint path (site-relative; prefixed with /proxy/network/api)
 		reader, // Reader with the file content
 		"myfile.txt", // Filename to use in the upload
 		"file", // Form field name for the file

--- a/docs/file_uploads.md
+++ b/docs/file_uploads.md
@@ -44,7 +44,7 @@ func main() {
 	var response map[string]interface{} // Adjust this type based on the expected response
 	err = client.UploadFile(
 		context.Background(),
-		"s/default/upload", // The API endpoint path (site-relative; prefixed with /proxy/network/api)
+		"/proxy/network/upload/s/default/portalfile", // Upload endpoint (leading slash ⇒ sent as-is; uploads live under /proxy/network/upload, outside the /proxy/network/api tree)
 		"/path/to/your/file.txt", // Path to the file on disk
 		"file", // Form field name for the file
 		formFields, // Additional form fields
@@ -89,7 +89,7 @@ func main() {
 	var response map[string]interface{} // Adjust this type based on the expected response
 	err = client.UploadFileFromReader(
 		context.Background(),
-		"s/default/upload", // The API endpoint path (site-relative; prefixed with /proxy/network/api)
+		"/proxy/network/upload/s/default/portalfile", // Upload endpoint (leading slash ⇒ sent as-is; uploads live under /proxy/network/upload, outside the /proxy/network/api tree)
 		reader, // Reader with the file content
 		"myfile.txt", // Filename to use in the upload
 		"file", // Form field name for the file

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,14 +5,15 @@ I highly recommend to use the latest version of UniFi Go SDK, as well as update 
 
 ## Prerequisites
 
-- Go 1.16 or later
+- Go 1.26 or later
+- UniFi Controller 9.0.108 or newer (new-style/UniFi-OS only; old-style controllers are unsupported)
 
 ## Installation
 
 Install the UniFi Go SDK by running:
 
 ```bash
-go get github.com/filipowm/go-unifi
+go get github.com/filipowm/go-unifi/v2
 ```
 
 If you need to regenerate the client code from the API specifications, run:
@@ -23,11 +24,9 @@ go generate unifi/codegen.go
 
 ## Initialization
 
-The client supports both API Key authentication and username/password authentication. Below are examples for both methods.
-Unifi client support both username/password and API Key authentication. It is recommended to use API Key authentication
-together with dedicated user restricted to local access only.
+The client uses API Key authentication exclusively. Username/password authentication was removed in 2.0.0.
 
-**IMPORTANT:** API Key authentication is available only since UniFi Controller version 9.0.108
+**IMPORTANT:** API Key authentication is available only since UniFi Controller version 9.0.108. Old-style (classic) controllers are unsupported.
 
 ### Obtaining an API Key
 
@@ -38,13 +37,12 @@ together with dedicated user restricted to local access only.
 5. Add a name for your API Key.
 6. Copy the key and store it securely, as it will only be displayed once.
 7. Click Done to ensure the key is hashed and securely stored.
-8. Use the API Key 🎉
 
 ### API Key Authentication
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
+    URL:    "https://unifi.localdomain",
     APIKey: "your-api-key",
 })
 if err != nil {
@@ -52,53 +50,25 @@ if err != nil {
 }
 ```
 
-### Username/Password Authentication
+### Deferring the startup check (SkipSystemInfo)
+
+By default, `NewClient` performs an eager `GetSystemInformation()` round-trip to verify connectivity and
+credentials at construction time. If you need fully-offline client construction (e.g. in tests or when
+you know the controller is reachable at call time but not at startup), set `SkipSystemInfo: true`:
 
 ```go
 c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    Username: "your-username",
-    Password: "your-password",
+    URL:            "https://unifi.localdomain",
+    APIKey:         "your-api-key",
+    SkipSystemInfo: true, // skip eager sysinfo check; errors surface on first API call
 })
 if err != nil {
     log.Fatalf("Failed to create client: %v", err)
 }
 ```
 
-You can also configure `Remember Me` option, which will prolong the session validity. Might be required for long-running applications, that require authentication only once.
-
-```go
-c, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    Username: "your-username",
-    Password: "your-password",
-    RememberMe: true,
-})
-if err != nil {
-    log.Fatalf("Failed to create client: %v", err)
-}
-```
-
-### Bare Client Initialization
-
-You can also use bare client, which creates a `unifi.Client` without initialization like logging in and getting system information. This can be useful in specific scenarios, when doing such initialization might be an uneeded overhead. To create it you can use the `NewBareClient` function provided in the SDK (see `unifi/client.go`).
-
-Example usage:
-
-```go
-c, err := unifi.NewBareClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi-controller.example.com",
-    APIKey: "your-api-key", // or use Username/Password as needed
-    // Configuration for a bare client
-})
-if err != nil {
-    log.Fatalf("Error creating bare client: %v", err)
-}
-err = c.Login()
-if err != nil {
-    log.Fatalf("Error logging in: %v", err)
-}
-```
+With `SkipSystemInfo: true` a bad API key or unreachable controller will NOT cause `NewClient` to fail —
+the error surfaces on the first actual API call instead.
 
 ## Generating Client Code
 
@@ -113,7 +83,7 @@ This will update the generated models and REST methods according to the current 
 
 ## Usage
 
-Once instantiated, the Bare Client provides direct access to the generated API methods. You can perform operations without the extra layers of processing provided by interceptors or custom validations.
+Once instantiated, the client provides direct access to the generated API methods.
 If you use a default site and didn't create any new ones, you can use the `default` site ID.
 
 **Example:**
@@ -144,7 +114,7 @@ if c.IsFeatureEnabled(ctx, "default", "feature-name") {
 }
 ```
 
-Library comes with a set of predefined feature names, which can be found in `github.com/filipowm/go-unifi/unifi/features` module. You can also use custom feature names.
+Library comes with a set of predefined feature names, which can be found in `github.com/filipowm/go-unifi/v2/unifi/features` module. You can also use custom feature names.
 
 For example, you can check if the `features.ZoneBasedFirewallMigration` is available on the controller (no `unifi.ErrNotFound` raised) and enabled:
 ```go

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ I highly recommend to use the latest version of UniFi Go SDK, as well as update 
 ## Prerequisites
 
 - Go 1.26 or later
-- UniFi Controller 9.0.108 or newer (new-style/UniFi-OS only; old-style controllers are unsupported)
+- UniFi Controller 9.0.114 or newer (new-style/UniFi-OS only; old-style controllers are unsupported)
 
 ## Installation
 
@@ -26,7 +26,7 @@ go generate unifi/codegen.go
 
 The client uses API Key authentication exclusively. Username/password authentication was removed in 2.0.0.
 
-**IMPORTANT:** API Key authentication is available only since UniFi Controller version 9.0.108. Old-style (classic) controllers are unsupported.
+**IMPORTANT:** API Key authentication is available only since UniFi Controller version 9.0.114. Old-style (classic) controllers are unsupported.
 
 ### Obtaining an API Key
 

--- a/docs/migrating_from_upstream.md
+++ b/docs/migrating_from_upstream.md
@@ -34,7 +34,7 @@ if err != nil {
 ### filipowm/go-unifi Style
 
 The new library provides a more structured and configurable approach. In 2.0.0, only API Key
-authentication is supported (available from UniFi Controller 9.0.108+):
+authentication is supported (available from UniFi Controller 9.0.114+):
 
 ```go
 client, err := unifi.NewClient(&unifi.ClientConfig{

--- a/docs/migrating_from_upstream.md
+++ b/docs/migrating_from_upstream.md
@@ -33,20 +33,13 @@ if err != nil {
 
 ### filipowm/go-unifi Style
 
-The new library provides a more structured and configurable approach:
+The new library provides a more structured and configurable approach. In 2.0.0, only API Key
+authentication is supported (available from UniFi Controller 9.0.108+):
 
 ```go
-// Using API Key (recommended, requires UniFi Controller 9.0.108+)
 client, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL: "https://unifi.localdomain",
-    APIKey:  "your-api-key",
-})
-
-// OR using username/password
-client, err := unifi.NewClient(&unifi.ClientConfig{
-    BaseURL:  "https://unifi.localdomain",
-    Username: "your-username",
-    Password: "your-password",
+    URL:    "https://unifi.localdomain",
+    APIKey: "your-api-key",
 })
 
 if err != nil {
@@ -62,7 +55,7 @@ if err != nil {
 
 2. **Authentication**:
    - Old: Only username/password authentication with explicit `Login()` call
-   - New: Supports both API Key (recommended) and username/password authentication
+   - New: API Key authentication only (username/password removed in 2.0.0)
    - New: Login is handled automatically during client creation
 
 3. **HTTP Client Configuration**:
@@ -83,19 +76,19 @@ if err != nil {
 
 ## Migration Steps
 
-1. Replace the import from `github.com/paultyng/go-unifi` to `github.com/filipowm/go-unifi`
-2. Replace manual client creation with `NewClient` and appropriate `ClientConfig`
+1. Replace the import from `github.com/paultyng/go-unifi` to `github.com/filipowm/go-unifi/v2`
+2. Replace manual client creation with `NewClient` and appropriate `ClientConfig` (API key required)
 3. TLS verification is now **on by default** (secure by default). To skip verification (e.g. self-signed
    certs), set `SkipVerifySSL` to `true` (the zero value `false` verifies), and
    disabling verification logs a warning:
    ```go
    client, err := unifi.NewClient(&unifi.ClientConfig{
-       BaseURL: "https://unifi.localdomain",
-       APIKey:  "your-api-key",
+       URL:           "https://unifi.localdomain",
+       APIKey:        "your-api-key",
        SkipVerifySSL: true,
    })
    ```
-4. Remove explicit `Login()` calls as they are now handled automatically, unless you use [bare client initialization](./getting_started.md#BareClientInitialization)
+4. Remove explicit `Login()` calls as they are now handled automatically
 5. Replace usage of `unifi.APIError` with `unifi.ServerError`
 
 The rest of your code using the client methods should continue to work as before, as the API methods remain the same.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,5 +12,7 @@ leveraging auto-generated models and manual enhancements for undocumented endpoi
 - [Usage Examples](usage_examples.md)
 - [Migrating from paultyng/go-unifi](migrating_from_upstream.md)
 - [Advanced Topics](advanced_topics.md)
+- [2.0.0 Migration Guide](2.0.0/migration_guide.md)
+- [2.0.0 Breaking Changes](2.0.0/breaking_changes.md)
 
 Each section is designed to help you understand and effectively utilize the UniFi client in your Go projects. 

--- a/unifi/doc.go
+++ b/unifi/doc.go
@@ -1,0 +1,30 @@
+// Package unifi provides a Go client for the UniFi Network Controller API.
+//
+// # Authentication
+//
+// Every client is created with [NewClient] using an API key (requires UniFi Network 9.0.108+
+// on new-style/UniFi-OS controllers). Old-style (classic) controllers are unsupported and
+// return [ErrOldStyleUnsupported] at construction time.
+//
+//	c, err := unifi.NewClient(&unifi.ClientConfig{
+//	    URL:    "https://unifi.example.com",
+//	    APIKey: "your-api-key",
+//	})
+//
+// # Internal vs Official API
+//
+// The client exposes two surfaces:
+//
+//   - Internal — the legacy Network API (all generated resource methods, e.g. GetNetwork,
+//     ListUser). Reachable directly on the client or via [Client.Internal].
+//   - Official — the official UniFi OpenAPI (integration/v1), reached via [Client.Official].
+//     Requires controller ≥ 10.1.78 with API-key auth. Operations return
+//     [ErrOfficialAPIUnavailable] on unsupported controllers.
+//
+// In 2.0.0 the Internal surface remains the default: existing code calling resource methods
+// directly on the client is unaffected. 3.0.0 is expected to flip the default to Official.
+//
+// # Concurrency
+//
+// A *client (and anything obtained from it) is safe for concurrent use by multiple goroutines.
+package unifi

--- a/unifi/doc.go
+++ b/unifi/doc.go
@@ -2,7 +2,7 @@
 //
 // # Authentication
 //
-// Every client is created with [NewClient] using an API key (requires UniFi Network 9.0.108+
+// Every client is created with [NewClient] using an API key (requires UniFi Network 9.0.114+
 // on new-style/UniFi-OS controllers). Old-style (classic) controllers are unsupported and
 // return [ErrOldStyleUnsupported] at construction time.
 //


### PR DESCRIPTION
Resolves the front-door docs work for #148. Single cohesive docs PR (no code changes except the new `unifi/doc.go` package comment).

## What changed

**A. Compile-fix** — every stale Go snippet now uses `URL:` + `APIKey:` only. Purged `BaseURL:` struct fields, `User`/`Username`/`Password`/`RememberMe`, `UserPassCredentials`, `.Login()`/`.Logout()`, and `NewBareClient` across `README.md`, `docs/getting_started.md`, `docs/configuration.md`, `docs/file_uploads.md`, `docs/advanced_topics.md`, `docs/migrating_from_upstream.md`. Go floor 1.16 → 1.26.

**B. Stale claims, badges, floor, package doc, `/v2` sweep** — godoc.org badge → pkg.go.dev `/v2`; `/v2` applied to import/install snippets only (bare repo URLs untouched); dropped "Any version after 5.12.35"; added a `2.0.0` row to `docs/compatibility_matrix.md`; new `unifi/doc.go` `// Package unifi` overview.

**C. Migration guide + breaking_changes reframe** — new `docs/2.0.0/migration_guide.md` (fast-path checklist + self-contained thematic sections, written junior→senior, inline `// before`/`// after`); `breaking_changes.md` reframed to "10 landed + additive Official surface", PENDING rows relocated to a "Planned for 3.0.0" section, provenance entries added for QOSProfile / SkipSystemInfo·NewBareClient / Patch. Both linked from README top and `docs/readme.md`.

**D. Raw-call escape hatch + Patch** — `advanced_topics.md` documents `Patch`, the leading-slash path-resolution rule, and site-relative form; README links it + the group→resource note (Vouchers under `Hotspot()`, `PatchPolicy` Firewall-only).

## Decisions worth flagging

- **Version floor → 9.0.114, not 9.0.108.** The issue body said 9.0.108, but the shipped runtime error (`unifi/api_paths.go` `ErrOldStyleUnsupported`: *"requires UniFi Network 9.0.114 or newer"*), the `docs/2.0.0/README.md` contract, and issue #126 all say **9.0.114**. Normalized all docs to 9.0.114 so they match the code users actually hit. Confirmed with the maintainer.
- **Landed-breaks only.** Each documented break was grep-verified present on `feat/2.0.0` before inclusion (QOSProfile `*DeviceQOSProfile`, `SkipSystemInfo` field, `NewBareClient` removed, `Patch` method). Nothing aspirational documented.
- **No `breaking` label** — docs describe already-landed breaks; this PR introduces no new break.

## Review remediation (in this PR)

Architect + test-lead review ran in-gate; blocker/major auto-remediated. The five minor/nit findings were also fixed before opening (maintainer's call):
- Patch examples no longer imply Internal `networkconf` accepts PATCH (it uses PUT) — point at a PATCH-capable `integration/v1` path + verb caveat.
- `file_uploads.md` upload path corrected to the real `/proxy/network/upload` tree (was wrongly annotated `/proxy/network/api`).
- Go 1.26 rationale now cites the `go.mod` toolchain baseline (iter.Seq2 only needs ≥1.23).
- "Planned for 3.0.0" rows prefixed `P4`/`P5`/`P6` so they don't collide with the renumbered landed rows 4–6.

## Gate

`go build ./...`, `go vet`, `golangci-lint run` (0 issues) all green in the worktree. Full `go test` was green in the workflow gate; remediation changed zero `.go` files. Internal markdown links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)