### PR TITLE
refactor(codegen): replace logrus with log/slog

### DIFF
--- a/codegen/internal/customize_test.go
+++ b/codegen/internal/customize_test.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -265,7 +263,7 @@ customizations:
 	cc, err := NewCodeCustomizer(tempFile)
 	require.NoError(t, err)
 
-	logger, hook := test.NewNullLogger()
+	logger, records := newCaptureLogger()
 	cc.logger = logger
 
 	// Unknown action is still returned (warn-and-ignore: AddResource simply never
@@ -274,12 +272,7 @@ customizations:
 	// "List" is invalid for a settings resource (only Get/Update exist).
 	assert.Equal(t, []string{"List"}, cc.ExcludedClientFunctions(&Resource{StructName: "SettingMgmt"}))
 
-	var msgs []string
-	for _, e := range hook.AllEntries() {
-		if e.Level == logrus.WarnLevel {
-			msgs = append(msgs, e.Message)
-		}
-	}
+	msgs := warnMessages(records())
 	assert.Contains(t, msgs, `excludeFunctions: unknown action "Updte" for resource Network (ignored)`)
 	assert.Contains(t, msgs, `excludeFunctions: unknown action "List" for resource SettingMgmt (ignored)`)
 }

--- a/codegen/internal/generator_test.go
+++ b/codegen/internal/generator_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,8 +101,7 @@ func TestGenerateCode_InjectedV2BaseDir(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fieldsDir, "Widget.json"), []byte(`{"name": ".{0,32}"}`), 0o644))  //nolint:gosec
 	require.NoError(t, os.WriteFile(filepath.Join(v2BaseDir, "Gadget.json"), []byte(`{"label": ".{0,32}"}`), 0o644)) //nolint:gosec
 
-	logger, hook := test.NewNullLogger()
-	logger.SetLevel(logrus.DebugLevel)
+	logger, records := newCaptureLogger()
 
 	err := generateCode(fieldsDir, v2BaseDir, outDir, CodeCustomizer{}, logger)
 	require.NoError(t, err)
@@ -116,7 +113,7 @@ func TestGenerateCode_InjectedV2BaseDir(t *testing.T) {
 	}
 
 	// The injected logger (not the package global) captured the pipeline output.
-	entries := hook.AllEntries()
+	entries := records()
 	debugMsgs := make([]string, 0, len(entries))
 	for _, e := range entries {
 		debugMsgs = append(debugMsgs, e.Message)

--- a/codegen/internal/log.go
+++ b/codegen/internal/log.go
@@ -2,14 +2,13 @@ package internal
 
 import (
 	"github.com/filipowm/go-unifi/v2/codegen/shared"
-	"github.com/sirupsen/logrus"
 )
 
 // log is the package-global logger used as the default sink when individual
 // pipeline components are constructed without an explicit logger. Functions that
 // accept a shared.Logger use orDefaultLogger so tests can inject an isolated
 // instance and assert output without touching this global.
-var log shared.Logger = logrus.New()
+var log = shared.DefaultLogger()
 
 // orDefaultLogger returns logger, or the package-global fallback when it is nil.
 func orDefaultLogger(logger shared.Logger) shared.Logger {

--- a/codegen/internal/logging_test.go
+++ b/codegen/internal/logging_test.go
@@ -1,0 +1,64 @@
+package internal //nolint:testpackage // tests access unexported symbols
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
+)
+
+// capturedRecord is one log entry recorded by captureHandler, reduced to the
+// level and message the tests assert on.
+type capturedRecord struct {
+	Level   slog.Level
+	Message string
+}
+
+// captureHandler is a slog.Handler that records every record into a shared,
+// mutex-guarded slice, letting tests inject an isolated logger and assert its
+// output in parallel without touching shared state.
+type captureHandler struct {
+	mu      *sync.Mutex
+	records *[]capturedRecord
+}
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, capturedRecord{Level: r.Level, Message: r.Message})
+	return nil
+}
+
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// newCaptureLogger returns a shared.Logger that records every entry and an
+// accessor returning a snapshot of the captured records. It captures at every
+// level (Enabled is always true), so callers need not set a minimum level.
+func newCaptureLogger() (shared.Logger, func() []capturedRecord) {
+	mu := &sync.Mutex{}
+	records := &[]capturedRecord{}
+	logger := shared.NewSlogLogger(slog.New(captureHandler{mu: mu, records: records}))
+	snapshot := func() []capturedRecord {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]capturedRecord, len(*records))
+		copy(out, *records)
+		return out
+	}
+	return logger, snapshot
+}
+
+// warnMessages returns the messages of all WARN-level captured records.
+func warnMessages(records []capturedRecord) []string {
+	var warns []string
+	for _, r := range records {
+		if r.Level == slog.LevelWarn {
+			warns = append(warns, r.Message)
+		}
+	}
+	return warns
+}

--- a/codegen/internal/resources_test.go
+++ b/codegen/internal/resources_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,19 +26,13 @@ func TestResourceWarningsUseInjectedLogger(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "Dropper.json"), []byte(`{"bad": 123}`), 0o644))                  //nolint:gosec
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "Collider.json"), []byte(`{"id": "", "i_d": ".{0,32}"}`), 0o644)) //nolint:gosec
 
-	logger, hook := test.NewNullLogger()
-	logger.SetLevel(logrus.DebugLevel)
+	logger, records := newCaptureLogger()
 
 	resources, err := buildResourcesFromDownloadedFields(tmpDir, CodeCustomizer{}, false, logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, resources)
 
-	var warns []string
-	for _, e := range hook.AllEntries() {
-		if e.Level == logrus.WarnLevel {
-			warns = append(warns, e.Message)
-		}
-	}
+	warns := warnMessages(records())
 	require.NotEmpty(t, warns, "injected logger must capture resource WARNs")
 	assertContainsSubstr(t, warns, "dropping field")
 	assertContainsSubstr(t, warns, "CamelCase collision on Go field")

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/filipowm/go-unifi/v2/codegen/internal"
 	"github.com/filipowm/go-unifi/v2/codegen/shared"
-	"github.com/sirupsen/logrus"
 )
 
 // Logger is an alias for shared.Logger so existing root code (options, tests)
@@ -26,7 +26,7 @@ type Logger = shared.Logger
 // generate() calls thread an injected logger instead, so the global
 // is only the CLI fallback — it is no longer the only sink, which is what made
 // the previous output-asserting tests racy and forced them to run serially.
-var log = logrus.New()
+var log = shared.DefaultLogger()
 
 // defaultLogger returns the package-global logger, used as the fallback when a
 // pipeline component is constructed without an explicit logger.
@@ -45,26 +45,24 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-// setupLogging configures and returns a *logrus.Logger at the level implied by
-// the debug/trace flags. The returned logger is what the CLI injects into
-// generate(); it intentionally does NOT mutate the package global so callers
-// (and tests) get an isolated, output-assertable instance.
-func setupLogging(debugEnabled, traceEnabled bool) *logrus.Logger {
-	l := logrus.New()
-	l.SetFormatter(&logrus.TextFormatter{
-		DisableTimestamp:       true,
-		DisableLevelTruncation: true,
-		ForceColors:            true,
-		FullTimestamp:          false,
-	})
-	if traceEnabled {
-		l.SetLevel(logrus.TraceLevel)
-	} else if debugEnabled {
-		l.SetLevel(logrus.DebugLevel)
-	} else {
-		l.SetLevel(logrus.InfoLevel)
+// logLevel maps the debug/trace flags to their slog.Level. trace wins over debug.
+func logLevel(debugEnabled, traceEnabled bool) slog.Level {
+	switch {
+	case traceEnabled:
+		return shared.LevelTrace
+	case debugEnabled:
+		return slog.LevelDebug
+	default:
+		return slog.LevelInfo
 	}
-	return l
+}
+
+// setupLogging configures and returns a slog-backed Logger at the level implied
+// by the debug/trace flags. The returned logger is what the CLI injects into
+// generate(); it intentionally does NOT mutate the package global so callers
+// (and tests) get an isolated instance.
+func setupLogging(debugEnabled, traceEnabled bool) Logger {
+	return shared.NewTextLogger(os.Stderr, logLevel(debugEnabled, traceEnabled))
 }
 
 type options struct {

--- a/codegen/main_test.go
+++ b/codegen/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/url"
 	"os"
 	"os/exec"
@@ -11,34 +12,35 @@ import (
 	"testing"
 
 	"github.com/filipowm/go-unifi/v2/codegen/internal"
+	"github.com/filipowm/go-unifi/v2/codegen/shared"
 	"github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSetupLogging asserts the level mapping on the logger RETURNED by
-// setupLogging. setupLogging no longer mutates the package-global logger (it
-// returns a fresh instance the CLI injects), so this test is now fully
-// parallel-safe and shares no state with any other test.
+// TestSetupLogging asserts the debug/trace flags map to the right slog.Level.
+// setupLogging returns a fresh slog-backed Logger the CLI injects (it never
+// mutates the package global), so this test is fully parallel-safe and shares
+// no state with any other test.
 func TestSetupLogging(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
 		debug, trace bool
-		want         logrus.Level
+		want         slog.Level
 	}{
-		"default is info":       {debug: false, trace: false, want: logrus.InfoLevel},
-		"debug enables debug":   {debug: true, trace: false, want: logrus.DebugLevel},
-		"trace enables trace":   {debug: false, trace: true, want: logrus.TraceLevel},
-		"trace wins over debug": {debug: true, trace: true, want: logrus.TraceLevel},
+		"default is info":       {debug: false, trace: false, want: slog.LevelInfo},
+		"debug enables debug":   {debug: true, trace: false, want: slog.LevelDebug},
+		"trace enables trace":   {debug: false, trace: true, want: shared.LevelTrace},
+		"trace wins over debug": {debug: true, trace: true, want: shared.LevelTrace},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			l := setupLogging(tc.debug, tc.trace)
-			assert.Equal(t, tc.want, l.Level)
+			assert.Equal(t, tc.want, logLevel(tc.debug, tc.trace))
+			// setupLogging builds a usable Logger at that level.
+			require.NotNil(t, setupLogging(tc.debug, tc.trace))
 		})
 	}
 }

--- a/codegen/shared/logging.go
+++ b/codegen/shared/logging.go
@@ -1,0 +1,59 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// LevelTrace is the slog level used for Trace logging. slog has no native Trace
+// level, so we use Debug-4 — the community convention for a level below Debug.
+const LevelTrace = slog.LevelDebug - 4
+
+// NewSlogLogger wraps a caller-supplied *slog.Logger into the pipeline Logger,
+// adapting slog's structured API to the printf/println-style methods the
+// generation pipeline depends on.
+func NewSlogLogger(l *slog.Logger) Logger {
+	return &slogLogger{logger: l}
+}
+
+// NewTextLogger returns a Logger backed by slog's text handler writing plain
+// text (no ANSI colours) to out at the given minimum level.
+func NewTextLogger(out io.Writer, level slog.Level) Logger {
+	handler := slog.NewTextHandler(out, &slog.HandlerOptions{Level: level})
+	return NewSlogLogger(slog.New(handler))
+}
+
+// DefaultLogger returns the fallback Logger used when a pipeline component is
+// constructed without an explicit one: slog text output to stderr at Info.
+func DefaultLogger() Logger {
+	return NewTextLogger(os.Stderr, slog.LevelInfo)
+}
+
+type slogLogger struct {
+	logger *slog.Logger
+}
+
+func (l *slogLogger) Tracef(format string, args ...any) { l.logf(LevelTrace, format, args...) }
+func (l *slogLogger) Debugf(format string, args ...any) { l.logf(slog.LevelDebug, format, args...) }
+func (l *slogLogger) Infof(format string, args ...any)  { l.logf(slog.LevelInfo, format, args...) }
+func (l *slogLogger) Warnf(format string, args ...any)  { l.logf(slog.LevelWarn, format, args...) }
+func (l *slogLogger) Errorf(format string, args ...any) { l.logf(slog.LevelError, format, args...) }
+
+func (l *slogLogger) Debugln(args ...any) { l.logln(slog.LevelDebug, args...) }
+func (l *slogLogger) Infoln(args ...any)  { l.logln(slog.LevelInfo, args...) }
+
+func (l *slogLogger) Error(args ...any) {
+	l.logger.Log(context.Background(), slog.LevelError, fmt.Sprint(args...))
+}
+
+func (l *slogLogger) logf(level slog.Level, format string, args ...any) {
+	l.logger.Log(context.Background(), level, fmt.Sprintf(format, args...))
+}
+
+func (l *slogLogger) logln(level slog.Level, args ...any) {
+	l.logger.Log(context.Background(), level, strings.TrimSuffix(fmt.Sprintln(args...), "\n"))
+}

--- a/codegen/shared/logging_test.go
+++ b/codegen/shared/logging_test.go
@@ -1,0 +1,96 @@
+package shared //nolint:testpackage // tests the slog adapter's level/format behavior directly
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ansiEscape is the CSI introducer; its absence proves no colour codes are emitted.
+const ansiEscape = "\x1b["
+
+// newBufferLogger builds a slog-backed Logger writing to buf at levelTrace so
+// every level (including Trace, which is below Debug) is captured.
+func newBufferLogger(buf *bytes.Buffer) Logger {
+	return NewSlogLogger(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: LevelTrace})))
+}
+
+func TestSlogLoggerLevelsAndFormatting(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	l := newBufferLogger(&buf)
+
+	l.Tracef("t=%d", 1)
+	l.Debugf("d=%s", "x")
+	l.Infof("i=%d", 2)
+	l.Warnf("w=%d", 3)
+	l.Errorf("e=%d", 4)
+	l.Debugln("dbg", "line")
+	l.Infoln("Structure JSONs ready!")
+	l.Error(errors.New("boom"))
+
+	out := buf.String()
+	assert.NotContains(t, out, ansiEscape, "text handler to a buffer must not emit ANSI colour codes")
+
+	// Each line carries the formatted message at the expected level.
+	wants := map[string]string{
+		"t=1":                    "level=DEBUG-4", // Trace maps to Debug-4
+		"d=x":                    "level=DEBUG",
+		"i=2":                    "level=INFO",
+		"w=3":                    "level=WARN",
+		"e=4":                    "level=ERROR",
+		"boom":                   "level=ERROR", // Error(args...) uses fmt.Sprint
+		"Structure JSONs ready!": "level=INFO",
+	}
+	for msg, level := range wants {
+		line := lineContaining(t, out, msg)
+		assert.Containsf(t, line, level, "message %q must be logged at %s", msg, level)
+	}
+
+	// Println-style methods join args with spaces and drop the trailing newline.
+	dbgLine := lineContaining(t, out, "dbg")
+	assert.Contains(t, dbgLine, `msg="dbg line"`, "Debugln must space-join args")
+	assert.NotContains(t, dbgLine, `\n`, "Debugln must not embed a trailing newline in the message")
+}
+
+func TestSlogLoggerHonorsMinLevel(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	l := NewTextLogger(&buf, slog.LevelWarn)
+
+	l.Tracef("trace-line")
+	l.Debugf("debug-line")
+	l.Infof("info-line")
+	l.Warnf("warn-line")
+	l.Errorf("error-line")
+
+	out := buf.String()
+	assert.NotContains(t, out, "trace-line")
+	assert.NotContains(t, out, "debug-line")
+	assert.NotContains(t, out, "info-line")
+	assert.Contains(t, out, "warn-line")
+	assert.Contains(t, out, "error-line")
+}
+
+func TestLevelTraceIsDebugMinus4(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, LevelTrace, slog.Level(-8), "Trace must map to Debug-4 (-8)")
+}
+
+// lineContaining returns the single output line containing substr, failing if
+// none is found.
+func lineContaining(t *testing.T, out, substr string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	require.Failf(t, "no log line found", "expected a line containing %q in:\n%s", substr, out)
+	return ""
+}

--- a/codegen/shared/shared.go
+++ b/codegen/shared/shared.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Logger is the minimal logging surface the generation pipeline depends on. It
-// is satisfied by *logrus.Logger (and *logrus.Entry), so production code can
-// inject a real logger while tests inject their own instance with a local hook,
+// is backed by log/slog (see NewSlogLogger), so production code can inject a real
+// logger while tests inject their own instance with a capturing handler,
 // asserting output in parallel without mutating shared state.
 type Logger interface {
 	Tracef(format string, args ...any)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/oapi-codegen/runtime v1.4.1
-	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/tj/assert v0.0.3
 	github.com/ulikunitz/xz v0.5.15

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
-github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Completes the logrus->slog migration started in #167, which left the codegen pipeline still on logrus. Back the printf-style shared.Logger with a slog adapter (shared/logging.go), swap the CLI/default loggers and the level mapping, and replace the logrus test hooks with a capturing slog.Handler. Drops the last github.com/sirupsen/logrus dependency.