### PR TITLE
fix(network): default absent `enabled` to true so import doesn't disable networks

### DIFF
--- a/codegen/internal/customizations.yml
+++ b/codegen/internal/customizations.yml
@@ -566,6 +566,14 @@ customizations:
           customUnmarshalType: ""
     Network:
       fields:
+        # `enabled` defaults to true on the controller and is absent from a healthy
+        # network's config; without this it unmarshals to the bool zero value false,
+        # poisoning imported state and disabling the network on the next full-replace
+        # PUT. emptyBoolToTrue maps absent/empty -> true (same as InternetAccessEnabled).
+        Enabled:
+          ifFieldType: "bool"
+          customUnmarshalType: "*bool"
+          customUnmarshalFunc: "emptyBoolToTrue"
         FirewallZoneID:
           omitEmpty: true
         InternetAccessEnabled:

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -275,6 +275,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 		DHCPDLeaseTime                 emptyStringInt `json:"dhcpd_leasetime"`
 		DHCPDTimeOffset                emptyStringInt `json:"dhcpd_time_offset"`
 		DHCPDV6LeaseTime               emptyStringInt `json:"dhcpdv6_leasetime"`
+		Enabled                        *bool          `json:"enabled"`
 		IGMPGroupmembership            emptyStringInt `json:"igmp_groupmembership"`
 		IGMPMaxresponse                emptyStringInt `json:"igmp_maxresponse"`
 		IGMPMcrtrexpiretime            emptyStringInt `json:"igmp_mcrtrexpiretime"`
@@ -285,7 +286,6 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 		IPV6RaValidLifetime            emptyStringInt `json:"ipv6_ra_valid_lifetime"`
 		InterfaceMtu                   emptyStringInt `json:"interface_mtu"`
 		InternetAccessEnabled          *bool          `json:"internet_access_enabled"`
-		Enabled                        *bool          `json:"enabled"`
 		LocalPort                      emptyStringInt `json:"local_port"`
 		OpenVPNLocalPort               emptyStringInt `json:"openvpn_local_port"`
 		OpenVPNRemotePort              emptyStringInt `json:"openvpn_remote_port"`
@@ -318,6 +318,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	dst.DHCPDLeaseTime = int(aux.DHCPDLeaseTime)
 	dst.DHCPDTimeOffset = int(aux.DHCPDTimeOffset)
 	dst.DHCPDV6LeaseTime = int(aux.DHCPDV6LeaseTime)
+	dst.Enabled = emptyBoolToTrue(aux.Enabled)
 	dst.IGMPGroupmembership = int(aux.IGMPGroupmembership)
 	dst.IGMPMaxresponse = int(aux.IGMPMaxresponse)
 	dst.IGMPMcrtrexpiretime = int(aux.IGMPMcrtrexpiretime)
@@ -328,7 +329,6 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	dst.IPV6RaValidLifetime = int(aux.IPV6RaValidLifetime)
 	dst.InterfaceMtu = int(aux.InterfaceMtu)
 	dst.InternetAccessEnabled = emptyBoolToTrue(aux.InternetAccessEnabled)
-	dst.Enabled = emptyBoolToTrue(aux.Enabled)
 	dst.LocalPort = int(aux.LocalPort)
 	dst.OpenVPNLocalPort = int(aux.OpenVPNLocalPort)
 	dst.OpenVPNRemotePort = int(aux.OpenVPNRemotePort)

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -285,6 +285,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 		IPV6RaValidLifetime            emptyStringInt `json:"ipv6_ra_valid_lifetime"`
 		InterfaceMtu                   emptyStringInt `json:"interface_mtu"`
 		InternetAccessEnabled          *bool          `json:"internet_access_enabled"`
+		Enabled                        *bool          `json:"enabled"`
 		LocalPort                      emptyStringInt `json:"local_port"`
 		OpenVPNLocalPort               emptyStringInt `json:"openvpn_local_port"`
 		OpenVPNRemotePort              emptyStringInt `json:"openvpn_remote_port"`
@@ -327,6 +328,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	dst.IPV6RaValidLifetime = int(aux.IPV6RaValidLifetime)
 	dst.InterfaceMtu = int(aux.InterfaceMtu)
 	dst.InternetAccessEnabled = emptyBoolToTrue(aux.InternetAccessEnabled)
+	dst.Enabled = emptyBoolToTrue(aux.Enabled)
 	dst.LocalPort = int(aux.LocalPort)
 	dst.OpenVPNLocalPort = int(aux.OpenVPNLocalPort)
 	dst.OpenVPNRemotePort = int(aux.OpenVPNRemotePort)

--- a/unifi/network_enabled_test.go
+++ b/unifi/network_enabled_test.go
@@ -1,16 +1,17 @@
-package unifi
+package unifi_test
 
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/filipowm/go-unifi/v2/unifi"
 )
 
-// Regression: an absent `enabled` key must unmarshal to true (not the bool zero
-// value false). The controller omits `enabled` for an enabled network, so without
-// this `terraform import` records enabled=false and the next full-replace PUT
-// disables the network.
+// Regression: an absent `enabled` key must unmarshal to true (the controller omits
+// it for an enabled network). Without this, terraform import records enabled=false
+// and the next full-replace PUT disables the network.
 func TestNetworkEnabledAbsentDefaultsTrue(t *testing.T) {
-	cases := []struct {
+	for _, c := range []struct {
 		name string
 		in   string
 		want bool
@@ -18,11 +19,10 @@ func TestNetworkEnabledAbsentDefaultsTrue(t *testing.T) {
 		{"absent -> true", `{"name":"WAN","purpose":"wan"}`, true},
 		{"explicit false -> false", `{"enabled":false}`, false},
 		{"explicit true -> true", `{"enabled":true}`, true},
-	}
-	for _, c := range cases {
-		var n Network
+	} {
+		var n unifi.Network
 		if err := json.Unmarshal([]byte(c.in), &n); err != nil {
-			t.Fatalf("%s: unmarshal: %v", c.name, err)
+			t.Fatalf("%s: %v", c.name, err)
 		}
 		if n.Enabled != c.want {
 			t.Errorf("%s: Enabled = %v, want %v", c.name, n.Enabled, c.want)

--- a/unifi/network_enabled_test.go
+++ b/unifi/network_enabled_test.go
@@ -1,0 +1,31 @@
+package unifi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Regression: an absent `enabled` key must unmarshal to true (not the bool zero
+// value false). The controller omits `enabled` for an enabled network, so without
+// this `terraform import` records enabled=false and the next full-replace PUT
+// disables the network.
+func TestNetworkEnabledAbsentDefaultsTrue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"absent -> true", `{"name":"WAN","purpose":"wan"}`, true},
+		{"explicit false -> false", `{"enabled":false}`, false},
+		{"explicit true -> true", `{"enabled":true}`, true},
+	}
+	for _, c := range cases {
+		var n Network
+		if err := json.Unmarshal([]byte(c.in), &n); err != nil {
+			t.Fatalf("%s: unmarshal: %v", c.name, err)
+		}
+		if n.Enabled != c.want {
+			t.Errorf("%s: Enabled = %v, want %v", c.name, n.Enabled, c.want)
+		}
+	}
+}

--- a/unifi/network_test.go
+++ b/unifi/network_test.go
@@ -72,6 +72,7 @@ func TestNetworkUnmarshalJSON(t *testing.T) {
 
 			// set some non-zero value defaults
 			expected := unifi.Network{
+				Enabled:               true,
 				InternetAccessEnabled: true,
 			}
 			c.expected(&expected)


### PR DESCRIPTION
## Problem

`Network.Enabled` is a plain `bool` with no special unmarshal handling. The controller **omits** the `enabled` key for an *enabled* network (it only serializes `enabled` when a network is explicitly disabled). So unmarshalling a healthy network decodes the absent `enabled` to the `bool` zero value `false`.

In the Terraform provider this is acute. `terraform import` of a network stores `enabled = false` in state (even though the network is on). The provider's Update builds a full-replace PUT from state, so the next `apply` sends `"enabled": false` and **disables the network** — and `terraform plan` shows nothing, because the `false` was baked in at import time. On a primary WAN, this took the internet down for hours.

## Fix

Apply the exact treatment already used for `internet_access_enabled` and `intra_network_access_enabled` (handled with `emptyBoolToTrue` since the original codegen): mark `Enabled` with `customUnmarshalType: "*bool"` + `customUnmarshalFunc: "emptyBoolToTrue"`, so an absent/empty `enabled` unmarshals to `true`. The struct field stays `bool`, so there is no downstream API change.

`enabled` is the same "default-true" category as those two sibling fields — it was simply missed when they were handled.

## Validation

- `network.generated.go` regenerated from `customizations.yml`; the only change is the `enabled` unmarshal handling (`aux *bool` + `dst.Enabled = emptyBoolToTrue(aux.Enabled)`). Struct field unchanged.
- Added a regression test (`network_enabled_test.go`): absent → `true`, explicit `false` → `false`, explicit `true` → `true`.
- `go build ./...` and `go test ./unifi/` pass.
